### PR TITLE
feat: initialize monorepo with bun workspaces and docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,67 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "oncall-agent",
+      "devDependencies": {
+        "typescript": "^5.4.0",
+      },
+    },
+    "packages/hypothesis-validator": {
+      "name": "@oncall/hypothesis-validator",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shared/types": "workspace:*",
+      },
+    },
+    "packages/investigation-agent": {
+      "name": "@oncall/investigation-agent",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shared/types": "workspace:*",
+      },
+    },
+    "packages/service-graph": {
+      "name": "@oncall/service-graph",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shared/mock-data": "workspace:*",
+        "@shared/types": "workspace:*",
+      },
+    },
+    "packages/slack-bot": {
+      "name": "@oncall/slack-bot",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shared/types": "workspace:*",
+      },
+    },
+    "shared/mock-data": {
+      "name": "@shared/mock-data",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shared/types": "workspace:*",
+      },
+    },
+    "shared/types": {
+      "name": "@shared/types",
+      "version": "0.1.0",
+    },
+  },
+  "packages": {
+    "@oncall/hypothesis-validator": ["@oncall/hypothesis-validator@workspace:packages/hypothesis-validator"],
+
+    "@oncall/investigation-agent": ["@oncall/investigation-agent@workspace:packages/investigation-agent"],
+
+    "@oncall/service-graph": ["@oncall/service-graph@workspace:packages/service-graph"],
+
+    "@oncall/slack-bot": ["@oncall/slack-bot@workspace:packages/slack-bot"],
+
+    "@shared/mock-data": ["@shared/mock-data@workspace:shared/mock-data"],
+
+    "@shared/types": ["@shared/types@workspace:shared/types"],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: oncall_agent
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d oncall_agent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "oncall-agent",
+  "version": "0.1.0",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "shared/*"
+  ],
+  "scripts": {
+    "dev": "bun run --filter '*' dev",
+    "build": "bun run --filter '*' build",
+    "lint": "bun run --filter '*' lint",
+    "typecheck": "bun run --filter '*' typecheck"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/hypothesis-validator/package.json
+++ b/packages/hypothesis-validator/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@oncall/hypothesis-validator",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shared/types": "workspace:*"
+  }
+}

--- a/packages/hypothesis-validator/src/index.ts
+++ b/packages/hypothesis-validator/src/index.ts
@@ -1,0 +1,15 @@
+import type { Hypothesis } from "@shared/types";
+
+export class HypothesisValidator {
+  async validate(hypothesis: Hypothesis): Promise<Hypothesis> {
+    // Placeholder: real implementation will query metrics, logs, traces
+    return {
+      ...hypothesis,
+      confidence: hypothesis.confidence,
+    };
+  }
+
+  rankHypotheses(hypotheses: Hypothesis[]): Hypothesis[] {
+    return [...hypotheses].sort((a, b) => b.confidence - a.confidence);
+  }
+}

--- a/packages/investigation-agent/package.json
+++ b/packages/investigation-agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@oncall/investigation-agent",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shared/types": "workspace:*"
+  }
+}

--- a/packages/investigation-agent/src/index.ts
+++ b/packages/investigation-agent/src/index.ts
@@ -1,0 +1,13 @@
+import type { Alert, InvestigationResult } from "@shared/types";
+
+export class InvestigationAgent {
+  async investigate(alert: Alert): Promise<InvestigationResult> {
+    return {
+      id: `inv-${Date.now()}`,
+      alertId: alert.id,
+      startedAt: new Date(),
+      status: "in_progress",
+      hypotheses: [],
+    };
+  }
+}

--- a/packages/service-graph/package.json
+++ b/packages/service-graph/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@oncall/service-graph",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shared/types": "workspace:*",
+    "@shared/mock-data": "workspace:*"
+  }
+}

--- a/packages/service-graph/src/index.ts
+++ b/packages/service-graph/src/index.ts
@@ -1,0 +1,31 @@
+import type { Service } from "@shared/types";
+
+export class ServiceGraph {
+  private services: Map<string, Service> = new Map();
+
+  addService(service: Service): void {
+    this.services.set(service.id, service);
+  }
+
+  getService(id: string): Service | undefined {
+    return this.services.get(id);
+  }
+
+  getDependencies(serviceId: string): Service[] {
+    const service = this.services.get(serviceId);
+    if (!service) return [];
+    return service.dependencies
+      .map((dep) => this.services.get(dep))
+      .filter((s): s is Service => s !== undefined);
+  }
+
+  getDownstreamImpact(serviceId: string): Service[] {
+    const affected: Service[] = [];
+    for (const service of this.services.values()) {
+      if (service.dependencies.includes(serviceId)) {
+        affected.push(service);
+      }
+    }
+    return affected;
+  }
+}

--- a/packages/slack-bot/package.json
+++ b/packages/slack-bot/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@oncall/slack-bot",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shared/types": "workspace:*"
+  }
+}

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -1,0 +1,15 @@
+import type { InvestigationResult } from "@shared/types";
+
+export class SlackBot {
+  async postInvestigationResult(
+    channel: string,
+    result: InvestigationResult
+  ): Promise<void> {
+    // Placeholder: real implementation will use Slack Web API
+    console.log(`[SlackBot] Posting to ${channel}:`, result.summary ?? result.status);
+  }
+
+  async postAlert(channel: string, message: string): Promise<void> {
+    console.log(`[SlackBot] Alert to ${channel}: ${message}`);
+  }
+}

--- a/shared/mock-data/index.ts
+++ b/shared/mock-data/index.ts
@@ -1,0 +1,72 @@
+import type { Alert, Service, Team } from "@shared/types";
+
+export const mockServices: Service[] = [
+  {
+    id: "svc-api-gateway",
+    name: "api-gateway",
+    team: "team-platform",
+    dependencies: ["svc-auth", "svc-user"],
+    healthStatus: "healthy",
+  },
+  {
+    id: "svc-auth",
+    name: "auth-service",
+    team: "team-security",
+    dependencies: ["svc-db-primary"],
+    healthStatus: "healthy",
+  },
+  {
+    id: "svc-user",
+    name: "user-service",
+    team: "team-platform",
+    dependencies: ["svc-db-primary", "svc-cache"],
+    healthStatus: "healthy",
+  },
+  {
+    id: "svc-db-primary",
+    name: "postgres-primary",
+    team: "team-infra",
+    dependencies: [],
+    healthStatus: "healthy",
+  },
+  {
+    id: "svc-cache",
+    name: "redis-cache",
+    team: "team-infra",
+    dependencies: [],
+    healthStatus: "healthy",
+  },
+];
+
+export const mockTeams: Team[] = [
+  {
+    id: "team-platform",
+    name: "Platform",
+    slackChannel: "#platform-oncall",
+    members: ["alice", "bob"],
+  },
+  {
+    id: "team-security",
+    name: "Security",
+    slackChannel: "#security-oncall",
+    members: ["charlie"],
+  },
+  {
+    id: "team-infra",
+    name: "Infrastructure",
+    slackChannel: "#infra-oncall",
+    members: ["dave", "eve"],
+  },
+];
+
+export const mockAlerts: Alert[] = [
+  {
+    id: "alert-001",
+    title: "High error rate on api-gateway",
+    severity: "critical",
+    service: "api-gateway",
+    timestamp: new Date("2024-01-15T10:30:00Z"),
+    labels: { env: "production", region: "us-east-1" },
+    description: "Error rate exceeded 5% threshold for 5 minutes",
+  },
+];

--- a/shared/mock-data/package.json
+++ b/shared/mock-data/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@shared/mock-data",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@shared/types": "workspace:*"
+  }
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,0 +1,47 @@
+export interface Alert {
+  id: string;
+  title: string;
+  severity: "critical" | "high" | "medium" | "low";
+  service: string;
+  timestamp: Date;
+  labels: Record<string, string>;
+  description?: string;
+}
+
+export interface Service {
+  id: string;
+  name: string;
+  team: string;
+  dependencies: string[];
+  healthStatus: "healthy" | "degraded" | "down" | "unknown";
+  metadata?: Record<string, string>;
+}
+
+export interface Team {
+  id: string;
+  name: string;
+  slackChannel: string;
+  oncallSchedule?: string;
+  members: string[];
+}
+
+export interface Hypothesis {
+  id: string;
+  description: string;
+  confidence: number;
+  evidence: string[];
+  relatedServices: string[];
+  suggestedActions: string[];
+}
+
+export interface InvestigationResult {
+  id: string;
+  alertId: string;
+  startedAt: Date;
+  completedAt?: Date;
+  status: "in_progress" | "completed" | "failed";
+  hypotheses: Hypothesis[];
+  rootCause?: string;
+  resolution?: string;
+  summary?: string;
+}

--- a/shared/types/package.json
+++ b/shared/types/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@shared/types",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@shared/types": ["shared/types/index.ts"],
+      "@shared/mock-data": ["shared/mock-data/index.ts"]
+    }
+  },
+  "exclude": [
+    "node_modules",
+    "**/node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- Initialize monorepo with bun workspaces covering `packages/*` and `shared/*`
- Add `docker-compose.yml` with `pgvector/pgvector:pg16` (port 5432, db: `oncall_agent`)
- Create `shared/types/index.ts` with all core interfaces: `Alert`, `Service`, `Team`, `Hypothesis`, `InvestigationResult`
- Add root `tsconfig.json` with `@shared/*` path aliases
- Scaffold all four packages with placeholder implementations

## Acceptance Criteria
- [x] `bun install` works from root (verified)
- [x] `docker-compose up -d` starts postgres (pgvector/pgvector:pg16 image configured)
- [x] `shared/types` can be imported from any package (verified via `bun run typecheck` — all 6 packages pass)

## Test plan
- [x] Run `bun install` from root — succeeds
- [x] Run `bun run typecheck` — all packages exit 0
- [ ] Run `docker-compose up -d` to verify postgres starts

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)