### PR TITLE
feat(service-graph): graph query functions — deps, owner, impact radius, deployments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "bun-types": "latest",
         "drizzle-kit": "^0.30.0",
       },
     },
@@ -125,6 +126,8 @@
     "@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 

--- a/packages/service-graph/package.json
+++ b/packages/service-graph/package.json
@@ -7,7 +7,8 @@
     "build": "bun build src/index.ts --outdir dist",
     "typecheck": "tsc --noEmit",
     "migrate": "bun run src/migrate.ts",
-    "seed": "bun run src/seed.ts"
+    "seed": "bun run src/seed.ts",
+    "test": "bun test src/queries.test.ts"
   },
   "dependencies": {
     "@shared/types": "workspace:*",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "drizzle-kit": "^0.30.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "bun-types": "latest"
   }
 }

--- a/packages/service-graph/src/queries.test.ts
+++ b/packages/service-graph/src/queries.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { eq } from "drizzle-orm";
+import path from "path";
+import {
+  services,
+  teams,
+  serviceOwnership,
+  serviceDependencies,
+  deployments,
+} from "./schema";
+import {
+  getDirectDependencies,
+  getTransitiveDependencies,
+  getServiceOwner,
+  findImpactRadius,
+  getRecentDeployments,
+} from "./queries";
+
+// Use a separate test DB via env or fall back to default
+const TEST_DB_URL =
+  process.env.TEST_DATABASE_URL ??
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/oncall_agent";
+
+let client: ReturnType<typeof postgres>;
+let db: ReturnType<typeof drizzle>;
+
+// IDs populated during setup
+let userDbId: string;
+let authServiceId: string;
+let paymentServiceId: string;
+let platformTeamId: string;
+
+beforeAll(async () => {
+  client = postgres(TEST_DB_URL);
+  db = drizzle(client);
+
+  await migrate(db, {
+    migrationsFolder: path.join(import.meta.dir, "../migrations"),
+  });
+
+  // Clean slate for test tables (order matters due to FK)
+  await db.execute(
+    // @ts-ignore — raw sql for truncation
+    `TRUNCATE deployments, incident_services, incidents, service_runbooks, runbooks, service_dependencies, service_ownership, services, teams RESTART IDENTITY CASCADE`
+  );
+
+  // Seed minimal test data
+  const [teamRow] = await db
+    .insert(teams)
+    .values({ name: "Platform", slackChannel: "#platform-oncall", oncallRotation: "platform-rota" })
+    .returning();
+  platformTeamId = teamRow!.id;
+
+  const svcRows = await db
+    .insert(services)
+    .values([
+      { name: "user-db",         tier: 3, language: null },
+      { name: "auth-service",    tier: 1, language: "Go" },
+      { name: "api-gateway",     tier: 1, language: "Go" },
+      { name: "payment-service", tier: 1, language: "Java" },
+      { name: "order-service",   tier: 1, language: "Java" },
+    ])
+    .returning();
+
+  const byName = new Map(svcRows.map((s) => [s.name, s.id]));
+  userDbId        = byName.get("user-db")!;
+  authServiceId   = byName.get("auth-service")!;
+  paymentServiceId = byName.get("payment-service")!;
+  const apiGwId   = byName.get("api-gateway")!;
+  const orderId   = byName.get("order-service")!;
+
+  // Ownership: Platform owns everything
+  await db.insert(serviceOwnership).values(
+    svcRows.map((s) => ({ serviceId: s.id, teamId: platformTeamId }))
+  );
+
+  // Dependencies: api-gateway → auth-service → user-db
+  //               api-gateway → payment-service
+  //               api-gateway → order-service
+  await db.insert(serviceDependencies).values([
+    { fromServiceId: apiGwId,        toServiceId: authServiceId,   dependencyType: "sync" },
+    { fromServiceId: apiGwId,        toServiceId: paymentServiceId, dependencyType: "sync" },
+    { fromServiceId: apiGwId,        toServiceId: orderId,          dependencyType: "sync" },
+    { fromServiceId: authServiceId,  toServiceId: userDbId,         dependencyType: "storage" },
+    { fromServiceId: paymentServiceId, toServiceId: userDbId,       dependencyType: "storage" },
+  ]);
+
+  // Deployments: 2 for auth-service in last 24h, 1 older
+  const now = Date.now();
+  await db.insert(deployments).values([
+    { serviceId: authServiceId, version: "1.2.0", commitSha: "abc123", deployedAt: new Date(now - 3_600_000),  deployer: "alice" },
+    { serviceId: authServiceId, version: "1.1.9", commitSha: "def456", deployedAt: new Date(now - 7_200_000),  deployer: "bob" },
+    { serviceId: authServiceId, version: "1.1.8", commitSha: "ghi789", deployedAt: new Date(now - 50_000_000), deployer: "ci" },
+  ]);
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+describe("getDirectDependencies", () => {
+  it("returns downstream services for api-gateway", async () => {
+    const apiGw = await db.select().from(services).where(eq(services.name, "api-gateway"));
+    const { downstream, upstream } = await getDirectDependencies(apiGw[0]!.id, TEST_DB_URL);
+    const names = downstream.map((s) => s.name).sort();
+    expect(names).toContain("auth-service");
+    expect(names).toContain("payment-service");
+    expect(names).toContain("order-service");
+    expect(upstream).toHaveLength(0); // nothing calls api-gateway
+  });
+
+  it("returns upstream services for auth-service", async () => {
+    const { upstream, downstream } = await getDirectDependencies(authServiceId, TEST_DB_URL);
+    expect(upstream.map((s) => s.name)).toContain("api-gateway");
+    expect(downstream.map((s) => s.name)).toContain("user-db");
+  });
+});
+
+describe("getTransitiveDependencies", () => {
+  it("returns multi-level deps for api-gateway at depth 3", async () => {
+    const apiGw = await db.select().from(services).where(eq(services.name, "api-gateway"));
+    const deps = await getTransitiveDependencies(apiGw[0]!.id, 3, TEST_DB_URL);
+    const toIds = deps.map((d) => d.toServiceId);
+    // depth 1: auth-service, payment-service, order-service
+    // depth 2: user-db (via auth and payment)
+    expect(toIds).toContain(authServiceId);
+    expect(toIds).toContain(paymentServiceId);
+    expect(toIds).toContain(userDbId);
+  });
+
+  it("respects depth limit", async () => {
+    const apiGw = await db.select().from(services).where(eq(services.name, "api-gateway"));
+    const deps = await getTransitiveDependencies(apiGw[0]!.id, 1, TEST_DB_URL);
+    expect(deps.every((d) => d.depth === 1)).toBe(true);
+    // user-db is at depth 2, should not appear
+    expect(deps.map((d) => d.toServiceId)).not.toContain(userDbId);
+  });
+});
+
+describe("getServiceOwner", () => {
+  it("returns team info for auth-service", async () => {
+    const owner = await getServiceOwner(authServiceId, TEST_DB_URL);
+    expect(owner).not.toBeNull();
+    expect(owner!.teamName).toBe("Platform");
+    expect(owner!.slackChannel).toBe("#platform-oncall");
+    expect(owner!.oncallRotation).toBe("platform-rota");
+  });
+
+  it("returns null for unknown service id", async () => {
+    const owner = await getServiceOwner("00000000-0000-0000-0000-000000000000", TEST_DB_URL);
+    expect(owner).toBeNull();
+  });
+});
+
+describe("findImpactRadius", () => {
+  it("returns all services that depend on user-db", async () => {
+    const impacted = await findImpactRadius(userDbId, TEST_DB_URL);
+    const names = impacted.map((s) => s.name);
+    // auth-service and payment-service directly depend on user-db
+    expect(names).toContain("auth-service");
+    expect(names).toContain("payment-service");
+    // api-gateway transitively depends on user-db
+    expect(names).toContain("api-gateway");
+  });
+
+  it("returns empty for a service no one depends on", async () => {
+    const apiGw = await db.select().from(services).where(eq(services.name, "api-gateway"));
+    const impacted = await findImpactRadius(apiGw[0]!.id, TEST_DB_URL);
+    expect(impacted).toHaveLength(0);
+  });
+});
+
+describe("getRecentDeployments", () => {
+  it("returns deployments within the last 24 hours", async () => {
+    const recent = await getRecentDeployments(authServiceId, 24, TEST_DB_URL);
+    expect(recent).toHaveLength(2);
+    expect(recent.map((d) => d.version)).toContain("1.2.0");
+    expect(recent.map((d) => d.version)).toContain("1.1.9");
+  });
+
+  it("excludes deployments older than the window", async () => {
+    const recent = await getRecentDeployments(authServiceId, 1, TEST_DB_URL);
+    // only the 1h-old deployment should be included
+    expect(recent).toHaveLength(1);
+    expect(recent[0]!.version).toBe("1.2.0");
+  });
+
+  it("returns empty for service with no recent deployments", async () => {
+    const recent = await getRecentDeployments(userDbId, 24, TEST_DB_URL);
+    expect(recent).toHaveLength(0);
+  });
+});

--- a/packages/service-graph/src/queries.ts
+++ b/packages/service-graph/src/queries.ts
@@ -1,0 +1,223 @@
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { eq, or, sql, and, gte } from "drizzle-orm";
+import {
+  services,
+  teams,
+  serviceOwnership,
+  serviceDependencies,
+  deployments,
+} from "./schema";
+
+export interface ServiceNode {
+  id: string;
+  name: string;
+  tier: number | null;
+  language: string | null;
+  repoUrl: string | null;
+}
+
+export interface DependencyEdge {
+  fromServiceId: string;
+  toServiceId: string;
+  dependencyType: string | null;
+}
+
+export interface ServiceOwnerInfo {
+  serviceId: string;
+  serviceName: string;
+  teamId: string;
+  teamName: string;
+  slackChannel: string | null;
+  oncallRotation: string | null;
+}
+
+export interface DeploymentRecord {
+  id: string;
+  serviceId: string | null;
+  version: string | null;
+  commitSha: string | null;
+  deployedAt: Date | null;
+  deployer: string | null;
+}
+
+export interface TransitiveDep {
+  fromServiceId: string;
+  toServiceId: string;
+  depth: number;
+}
+
+export function createDb(databaseUrl?: string) {
+  const url =
+    databaseUrl ??
+    process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5432/oncall_agent";
+  const client = postgres(url);
+  return { db: drizzle(client), client };
+}
+
+/** Returns immediate upstream and downstream services for a given service id. */
+export async function getDirectDependencies(
+  serviceId: string,
+  databaseUrl?: string
+): Promise<{ upstream: ServiceNode[]; downstream: ServiceNode[] }> {
+  const { db, client } = createDb(databaseUrl);
+
+  try {
+    // Downstream: services that serviceId calls
+    const downstreamEdges = await db
+      .select({ toServiceId: serviceDependencies.toServiceId })
+      .from(serviceDependencies)
+      .where(eq(serviceDependencies.fromServiceId, serviceId));
+
+    // Upstream: services that call serviceId
+    const upstreamEdges = await db
+      .select({ fromServiceId: serviceDependencies.fromServiceId })
+      .from(serviceDependencies)
+      .where(eq(serviceDependencies.toServiceId, serviceId));
+
+    const downstreamIds = downstreamEdges.map((e) => e.toServiceId).filter(Boolean) as string[];
+    const upstreamIds = upstreamEdges.map((e) => e.fromServiceId).filter(Boolean) as string[];
+
+    const [downstreamServices, upstreamServices] = await Promise.all([
+      downstreamIds.length
+        ? db.select().from(services).where(
+            sql`${services.id} = ANY(${sql.raw(`ARRAY['${downstreamIds.join("','")}']::uuid[]`)})`
+          )
+        : Promise.resolve([]),
+      upstreamIds.length
+        ? db.select().from(services).where(
+            sql`${services.id} = ANY(${sql.raw(`ARRAY['${upstreamIds.join("','")}']::uuid[]`)})`
+          )
+        : Promise.resolve([]),
+    ]);
+
+    return { upstream: upstreamServices, downstream: downstreamServices };
+  } finally {
+    await client.end();
+  }
+}
+
+/** Walks the dependency graph up to `depth` levels using a recursive CTE. */
+export async function getTransitiveDependencies(
+  serviceId: string,
+  depth: number,
+  databaseUrl?: string
+): Promise<TransitiveDep[]> {
+  const { db, client } = createDb(databaseUrl);
+
+  try {
+    const result = await db.execute(sql`
+      WITH RECURSIVE deps AS (
+        SELECT from_service_id, to_service_id, 1 AS depth
+        FROM service_dependencies
+        WHERE from_service_id = ${serviceId}::uuid
+        UNION ALL
+        SELECT d.from_service_id, sd.to_service_id, d.depth + 1
+        FROM deps d
+        JOIN service_dependencies sd ON sd.from_service_id = d.to_service_id
+        WHERE d.depth < ${depth}
+      )
+      SELECT DISTINCT from_service_id AS "fromServiceId",
+                      to_service_id   AS "toServiceId",
+                      depth
+      FROM deps
+      ORDER BY depth, from_service_id
+    `);
+
+    return (result as unknown as TransitiveDep[]);
+  } finally {
+    await client.end();
+  }
+}
+
+/** Returns team ownership info (name, Slack channel, on-call rotation) for a service. */
+export async function getServiceOwner(
+  serviceId: string,
+  databaseUrl?: string
+): Promise<ServiceOwnerInfo | null> {
+  const { db, client } = createDb(databaseUrl);
+
+  try {
+    const rows = await db
+      .select({
+        serviceId: services.id,
+        serviceName: services.name,
+        teamId: teams.id,
+        teamName: teams.name,
+        slackChannel: teams.slackChannel,
+        oncallRotation: teams.oncallRotation,
+      })
+      .from(services)
+      .innerJoin(serviceOwnership, eq(serviceOwnership.serviceId, services.id))
+      .innerJoin(teams, eq(teams.id, serviceOwnership.teamId))
+      .where(eq(services.id, serviceId));
+
+    return rows[0] ?? null;
+  } finally {
+    await client.end();
+  }
+}
+
+/** Returns all services that would be impacted if `serviceId` goes down (reverse transitive walk). */
+export async function findImpactRadius(
+  serviceId: string,
+  databaseUrl?: string
+): Promise<ServiceNode[]> {
+  const { db, client } = createDb(databaseUrl);
+
+  try {
+    const result = await db.execute(sql`
+      WITH RECURSIVE impact AS (
+        SELECT from_service_id AS affected_id, 1 AS depth
+        FROM service_dependencies
+        WHERE to_service_id = ${serviceId}::uuid
+        UNION ALL
+        SELECT sd.from_service_id, i.depth + 1
+        FROM impact i
+        JOIN service_dependencies sd ON sd.to_service_id = i.affected_id
+        WHERE i.depth < 10
+      )
+      SELECT DISTINCT s.id, s.name, s.tier, s.language, s.repo_url AS "repoUrl"
+      FROM impact i
+      JOIN services s ON s.id = i.affected_id
+      ORDER BY s.name
+    `);
+
+    return (result as unknown as { id: string; name: string; tier: number | null; language: string | null; repoUrl: string | null }[]).map((r) => ({
+      id: r.id,
+      name: r.name,
+      tier: r.tier ?? null,
+      language: r.language ?? null,
+      repoUrl: r.repoUrl ?? null,
+    }));
+  } finally {
+    await client.end();
+  }
+}
+
+/** Returns deployments for a service within the last `hours` hours. */
+export async function getRecentDeployments(
+  serviceId: string,
+  hours: number,
+  databaseUrl?: string
+): Promise<DeploymentRecord[]> {
+  const { db, client } = createDb(databaseUrl);
+
+  try {
+    const since = new Date(Date.now() - hours * 3600_000);
+    const rows = await db
+      .select()
+      .from(deployments)
+      .where(
+        and(
+          eq(deployments.serviceId, serviceId),
+          gte(deployments.deployedAt, since)
+        )
+      );
+
+    return rows;
+  } finally {
+    await client.end();
+  }
+}

--- a/packages/service-graph/tsconfig.json
+++ b/packages/service-graph/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"],
+    "types": ["node", "bun-types"],
     "baseUrl": ".",
     "paths": {
       "@shared/types": ["../../shared/types/index.ts"],


### PR DESCRIPTION
## Summary
Implements all 5 query functions the Investigation Agent will use as tools.

## Functions
| Function | Description |
|---|---|
| `getDirectDependencies(id)` | Immediate upstream (callers) + downstream (callees) |
| `getTransitiveDependencies(id, depth)` | Recursive CTE walk up to N levels |
| `getServiceOwner(id)` | Team name, Slack channel, on-call rotation |
| `findImpactRadius(id)` | All services impacted if this one goes down (reverse transitive) |
| `getRecentDeployments(id, hours)` | Deployments within last N hours |

## Tests (`queries.test.ts`)
- `getDirectDependencies` — downstream services for api-gateway, upstream for auth-service
- `getTransitiveDependencies` — multi-level graph at depth 3, depth limit respected
- `getServiceOwner` — correct team info, null for unknown id
- `findImpactRadius` — direct + transitive dependents of user-db, empty for root service
- `getRecentDeployments` — window filter (24h vs 1h), empty for service with no deploys

## Test plan
- [x] `bun run typecheck` — zero errors
- [ ] `bun run test` (requires running postgres)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)