### PR TITLE
Add confidence recalibration and escalation scoring layer

### DIFF
--- a/packages/hypothesis-validator/src/__tests__/scoring.test.ts
+++ b/packages/hypothesis-validator/src/__tests__/scoring.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "bun:test";
+import { recalibrateConfidence, shouldEscalate, rerankHypotheses } from "../scoring";
+import type { ValidatedHypothesis } from "../types";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeHypothesis(
+  overrides: Partial<ValidatedHypothesis> & Pick<ValidatedHypothesis, "revised_confidence">
+): ValidatedHypothesis {
+  return {
+    original_rank: 1,
+    original_confidence: overrides.revised_confidence,
+    challenge_score: 0,
+    key_objections: [],
+    missing_evidence: [],
+    ...overrides,
+  };
+}
+
+// ── recalibrateConfidence ──────────────────────────────────────────────────
+
+describe("recalibrateConfidence", () => {
+  it("challenge_score=0 leaves confidence unchanged", () => {
+    expect(recalibrateConfidence(87, 0)).toBe(87);
+  });
+
+  it("challenge_score=100 reduces confidence to 0", () => {
+    expect(recalibrateConfidence(87, 100)).toBe(0);
+  });
+
+  it("challenge_score=50 halves confidence", () => {
+    expect(recalibrateConfidence(80, 50)).toBe(40);
+  });
+
+  it("rounds to nearest integer", () => {
+    // 87 * (1 - 10/100) = 87 * 0.9 = 78.3 → rounds to 78
+    expect(recalibrateConfidence(87, 10)).toBe(78);
+  });
+
+  it("challenge_score=25 attenuates by 25%", () => {
+    expect(recalibrateConfidence(100, 25)).toBe(75);
+  });
+
+  it("handles confidence=0 regardless of challenge", () => {
+    expect(recalibrateConfidence(0, 60)).toBe(0);
+  });
+});
+
+// ── shouldEscalate ─────────────────────────────────────────────────────────
+
+describe("shouldEscalate — condition 1: revised_confidence < 40", () => {
+  it("escalates when top hypothesis revised_confidence = 39", () => {
+    const hypotheses = [
+      makeHypothesis({ original_rank: 1, revised_confidence: 39 }),
+      makeHypothesis({ original_rank: 2, revised_confidence: 20 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(true);
+  });
+
+  it("does NOT escalate when top revised_confidence = 40", () => {
+    const hypotheses = [
+      makeHypothesis({ original_rank: 1, revised_confidence: 40 }),
+      makeHypothesis({ original_rank: 2, revised_confidence: 10 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(false);
+  });
+
+  it("escalates when all hypotheses are low confidence", () => {
+    const hypotheses = [
+      makeHypothesis({ revised_confidence: 14 }),
+      makeHypothesis({ revised_confidence: 13 }),
+      makeHypothesis({ revised_confidence: 11 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(true);
+  });
+});
+
+describe("shouldEscalate — condition 2: no clear winner (top and second within 15)", () => {
+  it("escalates when top=55 and second=45 (gap=10)", () => {
+    const hypotheses = [
+      makeHypothesis({ revised_confidence: 55 }),
+      makeHypothesis({ revised_confidence: 45 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(true);
+  });
+
+  it("escalates when top=55 and second=41 (gap=14)", () => {
+    const hypotheses = [
+      makeHypothesis({ revised_confidence: 55 }),
+      makeHypothesis({ revised_confidence: 41 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(true);
+  });
+
+  it("does NOT escalate when gap=15 (boundary)", () => {
+    const hypotheses = [
+      makeHypothesis({ revised_confidence: 70 }),
+      makeHypothesis({ revised_confidence: 55 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(false);
+  });
+
+  it("does NOT escalate when gap=20", () => {
+    const hypotheses = [
+      makeHypothesis({ revised_confidence: 78 }),
+      makeHypothesis({ revised_confidence: 10 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(false);
+  });
+
+  it("does NOT trigger condition 2 for single hypothesis", () => {
+    // Single hypothesis, revised_confidence=50 → no condition triggers
+    const hypotheses = [makeHypothesis({ revised_confidence: 50 })];
+    expect(shouldEscalate(hypotheses)).toBe(false);
+  });
+});
+
+describe("shouldEscalate — condition 3: top hypothesis > 3 key_objections", () => {
+  it("escalates when top has 4 key_objections", () => {
+    const hypotheses = [
+      makeHypothesis({
+        revised_confidence: 65,
+        key_objections: ["obj1", "obj2", "obj3", "obj4"],
+      }),
+      makeHypothesis({ revised_confidence: 10 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(true);
+  });
+
+  it("does NOT escalate when top has exactly 3 key_objections", () => {
+    const hypotheses = [
+      makeHypothesis({
+        revised_confidence: 65,
+        key_objections: ["obj1", "obj2", "obj3"],
+      }),
+      makeHypothesis({ revised_confidence: 10 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(false);
+  });
+
+  it("evaluates key_objections on highest revised_confidence hypothesis, not original_rank", () => {
+    // h2 has higher revised_confidence than h1; h2 has ≤3 objections → no escalate
+    const hypotheses = [
+      makeHypothesis({
+        original_rank: 1,
+        revised_confidence: 30,
+        key_objections: ["obj1", "obj2", "obj3", "obj4"], // > 3 but not top
+      }),
+      makeHypothesis({
+        original_rank: 2,
+        revised_confidence: 75,
+        key_objections: ["one"],
+      }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(false);
+  });
+});
+
+describe("shouldEscalate — empty array", () => {
+  it("escalates when hypotheses array is empty", () => {
+    expect(shouldEscalate([])).toBe(true);
+  });
+});
+
+// ── Scenario-level acceptance criteria ────────────────────────────────────
+
+describe("Scenario A acceptance: should NOT escalate", () => {
+  it("Scenario A top hypothesis revised_confidence ≥60%", () => {
+    const hypotheses = [
+      makeHypothesis({ revised_confidence: 78, key_objections: ["minor ambiguity"] }),
+      makeHypothesis({ revised_confidence: 10 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(false);
+    expect(hypotheses[0]!.revised_confidence).toBeGreaterThanOrEqual(60);
+  });
+});
+
+describe("Scenario C acceptance: should escalate", () => {
+  it("Scenario C escalates via condition 1 (revised_confidence < 40)", () => {
+    const hypotheses = [
+      makeHypothesis({ revised_confidence: 14, key_objections: ["obj1", "obj2", "obj3"] }),
+      makeHypothesis({ revised_confidence: 13 }),
+      makeHypothesis({ revised_confidence: 11 }),
+    ];
+    expect(shouldEscalate(hypotheses)).toBe(true);
+  });
+});
+
+// ── rerankHypotheses ───────────────────────────────────────────────────────
+
+describe("rerankHypotheses", () => {
+  it("sorts by revised_confidence descending", () => {
+    const hypotheses = [
+      makeHypothesis({ original_rank: 1, revised_confidence: 20 }),
+      makeHypothesis({ original_rank: 2, revised_confidence: 78 }),
+      makeHypothesis({ original_rank: 3, revised_confidence: 40 }),
+    ];
+    const reranked = rerankHypotheses(hypotheses);
+    expect(reranked[0]!.revised_confidence).toBe(78);
+    expect(reranked[1]!.revised_confidence).toBe(40);
+    expect(reranked[2]!.revised_confidence).toBe(20);
+  });
+
+  it("updates original_rank to reflect new order", () => {
+    const hypotheses = [
+      makeHypothesis({ original_rank: 1, revised_confidence: 10 }),
+      makeHypothesis({ original_rank: 2, revised_confidence: 75 }),
+    ];
+    const reranked = rerankHypotheses(hypotheses);
+    expect(reranked[0]!.original_rank).toBe(1);
+    expect(reranked[1]!.original_rank).toBe(2);
+  });
+
+  it("does not mutate the original array", () => {
+    const hypotheses = [
+      makeHypothesis({ original_rank: 1, revised_confidence: 10 }),
+      makeHypothesis({ original_rank: 2, revised_confidence: 75 }),
+    ];
+    rerankHypotheses(hypotheses);
+    expect(hypotheses[0]!.revised_confidence).toBe(10);
+  });
+});

--- a/packages/hypothesis-validator/src/scoring.ts
+++ b/packages/hypothesis-validator/src/scoring.ts
@@ -1,0 +1,58 @@
+import type { ValidatedHypothesis } from "./types";
+
+// ── Recalibration ──────────────────────────────────────────────────────────
+
+/**
+ * Attenuate an investigation agent's confidence score by how strongly the
+ * adversarial validator challenged the hypothesis.
+ *
+ * challenge_score=0   → no change
+ * challenge_score=100 → confidence drops to 0
+ */
+export function recalibrateConfidence(
+  originalConfidence: number,
+  challengeScore: number
+): number {
+  const attenuation = 1 - challengeScore / 100;
+  return Math.round(originalConfidence * attenuation);
+}
+
+// ── Escalation ─────────────────────────────────────────────────────────────
+
+/**
+ * Decide whether the investigation should be escalated to a human.
+ *
+ * Escalates when ANY of the following is true:
+ * 1. Top hypothesis revised_confidence < 40  (low overall certainty)
+ * 2. Top and second hypothesis are within 15 points  (no clear winner)
+ * 3. Top hypothesis has more than 3 key_objections  (heavily challenged)
+ */
+export function shouldEscalate(hypotheses: ValidatedHypothesis[]): boolean {
+  if (hypotheses.length === 0) return true;
+
+  const sorted = [...hypotheses].sort((a, b) => b.revised_confidence - a.revised_confidence);
+  const top = sorted[0]!;
+
+  // Condition 1: top hypothesis confidence too low
+  if (top.revised_confidence < 40) return true;
+
+  // Condition 2: no clear winner (top and second within 15 points)
+  const second = sorted[1];
+  if (second !== undefined && top.revised_confidence - second.revised_confidence < 15) return true;
+
+  // Condition 3: top hypothesis heavily objected to
+  if (top.key_objections.length > 3) return true;
+
+  return false;
+}
+
+// ── Re-ranking ─────────────────────────────────────────────────────────────
+
+/**
+ * Sort hypotheses by revised_confidence descending and assign updated ranks.
+ */
+export function rerankHypotheses(hypotheses: ValidatedHypothesis[]): ValidatedHypothesis[] {
+  return [...hypotheses]
+    .sort((a, b) => b.revised_confidence - a.revised_confidence)
+    .map((h, i) => ({ ...h, original_rank: i + 1 }));
+}

--- a/packages/hypothesis-validator/src/types.ts
+++ b/packages/hypothesis-validator/src/types.ts
@@ -1,0 +1,19 @@
+// ── Shared types for hypothesis-validator ─────────────────────────────────
+
+export interface ValidatedHypothesis {
+  original_rank: number;
+  original_confidence: number;
+  challenge_score: number;
+  key_objections: string[];
+  missing_evidence: string[];
+  alternative_explanation?: string;
+  revised_confidence: number;
+}
+
+export interface ValidationResult {
+  incident_id: string;
+  validated_hypotheses: ValidatedHypothesis[];
+  escalate: boolean;
+  escalation_reason?: string;
+  validator_notes: string;
+}

--- a/packages/hypothesis-validator/src/validator.ts
+++ b/packages/hypothesis-validator/src/validator.ts
@@ -1,23 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { InvestigationResult } from "@shared/types";
-
-// ── Types ──────────────────────────────────────────────────────────────────
-
-export interface ValidationResult {
-  incident_id: string;
-  validated_hypotheses: Array<{
-    original_rank: number;
-    original_confidence: number;
-    challenge_score: number;        // 0-100: how strongly challenged
-    key_objections: string[];
-    missing_evidence: string[];     // what would confirm or deny
-    alternative_explanation?: string;
-    revised_confidence: number;     // = original * (1 - challenge_score/100)
-  }>;
-  escalate: boolean;                // true if top hypothesis revised_confidence < 40%
-  escalation_reason?: string;
-  validator_notes: string;
-}
+import type { ValidationResult } from "./types";
+export type { ValidationResult } from "./types";
 
 export interface ValidateOptions {
   apiKey?: string;


### PR DESCRIPTION
## Summary
- Extracts `ValidatedHypothesis` / `ValidationResult` types into `src/types.ts` for shared use
- Implements `scoring.ts` with three pure functions:
  - `recalibrateConfidence(original, challengeScore)` — linear attenuation formula
  - `shouldEscalate(hypotheses)` — 3 independent escalation conditions
  - `rerankHypotheses(hypotheses)` — sort by `revised_confidence` descending

## Escalation conditions
1. Top hypothesis `revised_confidence < 40`
2. Top and second hypothesis within 15 points (no clear winner)
3. Top hypothesis has `> 3 key_objections` (heavily challenged)

## Test plan
- [x] `recalibrateConfidence`: boundary values (0, 50, 100 challenge), rounding
- [x] `shouldEscalate` condition 1: revised<40 triggers, =40 does not
- [x] `shouldEscalate` condition 2: gap=14 triggers, gap=15 does not
- [x] `shouldEscalate` condition 3: 4 objections triggers, 3 does not
- [x] Condition 3 evaluates the highest-confidence hypothesis, not original_rank
- [x] `rerankHypotheses`: order, rank update, no mutation
- [x] Scenario A acceptance: top revised≥60%, no escalation
- [x] Scenario C acceptance: escalates via condition 1
- [x] 41/41 tests pass (`bun test`)
- [x] `tsc --noEmit` clean

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)