### PR TITLE
Compose Investigation Agent + Hypothesis Validator into full pipeline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,13 @@
       "name": "@oncall/hypothesis-validator",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.36.3",
+        "@oncall/investigation-agent": "workspace:*",
+        "@shared/mock-data": "workspace:*",
         "@shared/types": "workspace:*",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
       },
     },
     "packages/investigation-agent": {

--- a/packages/hypothesis-validator/package.json
+++ b/packages/hypothesis-validator/package.json
@@ -6,10 +6,13 @@
     "dev": "bun run --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist",
     "typecheck": "tsc --noEmit",
-    "test": "bun test src/__tests__"
+    "test": "bun test src/__tests__",
+    "investigate": "bun run src/pipeline-cli.ts"
   },
   "dependencies": {
     "@shared/types": "workspace:*",
+    "@shared/mock-data": "workspace:*",
+    "@oncall/investigation-agent": "workspace:*",
     "@anthropic-ai/sdk": "^0.36.3"
   },
   "devDependencies": {

--- a/packages/hypothesis-validator/src/__tests__/investigation-fixtures.ts
+++ b/packages/hypothesis-validator/src/__tests__/investigation-fixtures.ts
@@ -1,0 +1,239 @@
+/**
+ * Re-export investigation-agent fixtures for use in pipeline tests.
+ * Copied to avoid cross-package test import issues.
+ */
+type LooseMessage = Omit<import("@anthropic-ai/sdk/resources/messages/messages").Message, "content"> & {
+  content: unknown[];
+};
+
+function usage() {
+  return { input_tokens: 1200, output_tokens: 480, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 };
+}
+
+// ── Scenario A: Deploy regression ─────────────────────────────────────────
+
+export const scenarioAResponses: LooseMessage[] = [
+  {
+    id: "msg_a1",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "tool_use",
+    stop_sequence: null,
+    usage: usage(),
+    content: [
+      { type: "text", text: "I'll investigate the payment-service incident. Let me gather evidence in parallel." },
+      { type: "tool_use", id: "tu_a1", name: "query_metrics",     input: { service: "payment-service" } },
+      { type: "tool_use", id: "tu_a2", name: "get_recent_deploys", input: { service: "payment-service", hours: 4 } },
+      { type: "tool_use", id: "tu_a3", name: "search_logs",        input: { service: "payment-service", level: "ERROR" } },
+      { type: "tool_use", id: "tu_a4", name: "get_service_deps",   input: { service: "payment-service" } },
+    ],
+  },
+  {
+    id: "msg_a2",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 3800, output_tokens: 620, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          hypotheses: [
+            {
+              rank: 1,
+              description: "Deploy abc123 (v2.4.1) introduced a NullPointerException in PaymentProcessor.java:247 — ProviderFactory.getProvider() returns null when Stripe SCA config is missing",
+              confidence: 87,
+              supporting_evidence: [
+                "Deploy abc123 at 14:28 touched PaymentProcessor.java and ProviderFactory.java",
+                "Error rate spiked from 0.3% to 7.8% at 14:30, exactly 2 minutes after deploy",
+                "Logs show NullPointerException at PaymentProcessor.java:247 starting 14:31:07",
+              ],
+              suggested_action: "Roll back payment-service to v2.4.0 via kubectl rollout undo",
+              runbook_url: "https://wiki.example.com/runbooks/rollback",
+            },
+            {
+              rank: 2,
+              description: "Missing Stripe SCA provider configuration in payment-providers.yml introduced alongside deploy abc123",
+              confidence: 13,
+              supporting_evidence: [
+                "config/payment-providers.yml was modified in abc123",
+                "Log message references missing payment.provider.stripe config key",
+              ],
+              suggested_action: "Review payment-providers.yml for missing Stripe SCA config entries",
+              runbook_url: "https://wiki.example.com/runbooks/null-pointer",
+            },
+          ],
+          timeline: [],
+          summary: "Deploy abc123 introduced NPE in PaymentProcessor — recommend immediate rollback to v2.4.0",
+        }),
+      },
+    ],
+  },
+];
+
+// ── Scenario B: Upstream dependency failure ───────────────────────────────
+
+export const scenarioBResponses: LooseMessage[] = [
+  {
+    id: "msg_b1",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "tool_use",
+    stop_sequence: null,
+    usage: usage(),
+    content: [
+      { type: "text", text: "I'll investigate the order-service latency spike." },
+      { type: "tool_use", id: "tu_b1", name: "query_metrics",     input: { service: "order-service" } },
+      { type: "tool_use", id: "tu_b2", name: "get_recent_deploys", input: { service: "order-service", hours: 48 } },
+      { type: "tool_use", id: "tu_b3", name: "get_service_deps",   input: { service: "order-service" } },
+      { type: "tool_use", id: "tu_b4", name: "search_logs",        input: { service: "order-service", keyword: "timeout" } },
+    ],
+  },
+  {
+    id: "msg_b2",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "tool_use",
+    stop_sequence: null,
+    usage: usage(),
+    content: [
+      { type: "text", text: "order-service depends on inventory-service. Checking its metrics." },
+      { type: "tool_use", id: "tu_b5", name: "query_metrics",      input: { service: "inventory-service" } },
+      { type: "tool_use", id: "tu_b6", name: "search_logs",        input: { service: "inventory-service", keyword: "connection" } },
+      { type: "tool_use", id: "tu_b7", name: "get_recent_deploys", input: { service: "inventory-service", hours: 48 } },
+      { type: "tool_use", id: "tu_b8", name: "get_past_incidents", input: { service: "inventory-service" } },
+    ],
+  },
+  {
+    id: "msg_b3",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 5200, output_tokens: 740, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          hypotheses: [
+            {
+              rank: 1,
+              description: "inventory-db connection pool exhausted (100/100 connections), causing inventory-service CPU spike to 94% and cascading latency to order-service",
+              confidence: 91,
+              supporting_evidence: [
+                "inventory-service CPU spiked from 28% to 94% at 09:22",
+                "inventory-db connection pool wait time jumped from 2ms to 4800ms",
+                "Logs: Connection pool exhausted: all 100 connections in use, queries queued: 47",
+              ],
+              suggested_action: "Kill idle inventory-db connections, temporarily increase pool size, deploy PgBouncer",
+              runbook_url: "https://wiki.example.com/runbooks/connection-pool",
+            },
+            {
+              rank: 2,
+              description: "inventory-db hardware or network issue causing I/O saturation",
+              confidence: 9,
+              supporting_evidence: ["No code changes correlate with incident"],
+              suggested_action: "Check inventory-db slow query log and disk I/O metrics",
+              runbook_url: "https://wiki.example.com/runbooks/slow-query",
+            },
+          ],
+          timeline: [],
+          summary: "inventory-db connection pool exhausted, cascading latency to order-service",
+        }),
+      },
+    ],
+  },
+];
+
+// ── Scenario C: No clear cause ────────────────────────────────────────────
+
+export const scenarioCResponses: LooseMessage[] = [
+  {
+    id: "msg_c1",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "tool_use",
+    stop_sequence: null,
+    usage: usage(),
+    content: [
+      { type: "text", text: "Investigating intermittent fraud-service errors." },
+      { type: "tool_use", id: "tu_c1", name: "query_metrics",     input: { service: "fraud-service" } },
+      { type: "tool_use", id: "tu_c2", name: "get_recent_deploys", input: { service: "fraud-service", hours: 72 } },
+      { type: "tool_use", id: "tu_c3", name: "search_logs",        input: { service: "fraud-service", level: "ERROR" } },
+      { type: "tool_use", id: "tu_c4", name: "get_service_deps",   input: { service: "fraud-service" } },
+    ],
+  },
+  {
+    id: "msg_c2",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "tool_use",
+    stop_sequence: null,
+    usage: usage(),
+    content: [
+      { type: "text", text: "Errors appear transient. Checking past incidents." },
+      { type: "tool_use", id: "tu_c5", name: "search_runbooks",    input: { keywords: ["intermittent", "model", "retry"] } },
+      { type: "tool_use", id: "tu_c6", name: "get_past_incidents", input: { service: "fraud-service" } },
+    ],
+  },
+  {
+    id: "msg_c3",
+    type: "message",
+    role: "assistant",
+    model: "claude-sonnet-4-6",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 4100, output_tokens: 580, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          hypotheses: [
+            {
+              rank: 1,
+              description: "Intermittent network instability between fraud-service and fraud-model-svc causing transient connection resets and read timeouts",
+              confidence: 35,
+              supporting_evidence: [
+                "Errors appear at irregular intervals (7 spikes over 60 minutes)",
+                "All failures are transient — retries succeed in 2-3 attempts",
+                "No recent deploys (last deploy 4 days ago)",
+              ],
+              suggested_action: "Monitor network metrics between fraud-service and fraud-model-svc pods",
+              runbook_url: "https://wiki.example.com/runbooks/null-pointer",
+            },
+            {
+              rank: 2,
+              description: "fraud-model-svc experiencing periodic GC pauses causing intermittent slowness",
+              confidence: 28,
+              supporting_evidence: [
+                "Pattern consistent with GC stop-the-world pauses (short duration, self-resolving)"
+              ],
+              suggested_action: "Check fraud-model-svc heap metrics and GC logs",
+              runbook_url: "https://wiki.example.com/runbooks/memory-leak",
+            },
+            {
+              rank: 3,
+              description: "External rate limiting from an underlying ML infrastructure dependency",
+              confidence: 22,
+              supporting_evidence: [
+                "Past incident inc-007 involved fraud model issues"
+              ],
+              suggested_action: "Check ML feature store quota metrics",
+              runbook_url: "https://wiki.example.com/runbooks/slow-query",
+            },
+          ],
+          timeline: [],
+          summary: "fraud-service showing intermittent errors with no clear root cause — evidence inconclusive, human investigation recommended",
+        }),
+      },
+    ],
+  },
+];

--- a/packages/hypothesis-validator/src/__tests__/pipeline.test.ts
+++ b/packages/hypothesis-validator/src/__tests__/pipeline.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { ScenarioName } from "@shared/mock-data";
+import { getScenario } from "@shared/mock-data";
+import type { Alert } from "@shared/types";
+import { runFullInvestigation } from "../pipeline";
+import { scenarioAResponses, scenarioBResponses } from "./investigation-fixtures";
+import { scenarioAValidatorResponse, scenarioCValidatorResponse } from "./fixtures";
+import { scenarioCResponses } from "./investigation-fixtures";
+
+// ── Mock client factories ──────────────────────────────────────────────────
+
+function makeSequentialClient(responses: unknown[]) {
+  let callIndex = 0;
+  return {
+    messages: {
+      create: mock(async () => {
+        const response = responses[callIndex];
+        if (!response) throw new Error(`No fixture for call ${callIndex}`);
+        callIndex++;
+        return response;
+      }),
+    },
+  };
+}
+
+function makeSingleClient(response: unknown) {
+  return {
+    messages: {
+      create: mock(async () => response),
+    },
+  };
+}
+
+// ── Alert builder ──────────────────────────────────────────────────────────
+
+function alertFromScenario(scenario: ScenarioName): Alert {
+  const s = getScenario(scenario);
+  return {
+    id: `test-alert-${scenario}`,
+    title: s.triggerAlert.title,
+    severity: s.triggerAlert.severity,
+    service: s.triggerAlert.service,
+    timestamp: new Date(s.triggerAlert.firedAt),
+    labels: { env: "production", scenario },
+    description: s.description,
+  };
+}
+
+// ── Scenario A: end-to-end pipeline ───────────────────────────────────────
+
+describe("Pipeline — Scenario A (deploy-regression)", () => {
+  it("returns FullInvestigationResult with required fields", async () => {
+    const alert = alertFromScenario("deploy-regression");
+    const result = await runFullInvestigation(alert, {
+      scenario: "deploy-regression",
+      investigationClient: makeSequentialClient(scenarioAResponses) as never,
+      validationClient: makeSingleClient(scenarioAValidatorResponse) as never,
+    });
+
+    expect(result.alert).toBe(alert);
+    expect(result.investigation).toBeDefined();
+    expect(result.validation).toBeDefined();
+    expect(Array.isArray(result.final_hypotheses)).toBe(true);
+    expect(typeof result.escalate).toBe("boolean");
+    expect(typeof result.investigation_duration_ms).toBe("number");
+    expect(typeof result.validation_duration_ms).toBe("number");
+    expect(typeof result.total_duration_ms).toBe("number");
+  });
+
+  it("total_duration_ms = investigation + validation duration", async () => {
+    const alert = alertFromScenario("deploy-regression");
+    const result = await runFullInvestigation(alert, {
+      scenario: "deploy-regression",
+      investigationClient: makeSequentialClient(scenarioAResponses) as never,
+      validationClient: makeSingleClient(scenarioAValidatorResponse) as never,
+    });
+    expect(result.total_duration_ms).toBe(
+      result.investigation_duration_ms + result.validation_duration_ms
+    );
+  });
+
+  it("does NOT escalate for Scenario A", async () => {
+    const alert = alertFromScenario("deploy-regression");
+    const result = await runFullInvestigation(alert, {
+      scenario: "deploy-regression",
+      investigationClient: makeSequentialClient(scenarioAResponses) as never,
+      validationClient: makeSingleClient(scenarioAValidatorResponse) as never,
+    });
+    expect(result.escalate).toBe(false);
+  });
+
+  it("final_hypotheses sorted by revised_confidence descending", async () => {
+    const alert = alertFromScenario("deploy-regression");
+    const result = await runFullInvestigation(alert, {
+      scenario: "deploy-regression",
+      investigationClient: makeSequentialClient(scenarioAResponses) as never,
+      validationClient: makeSingleClient(scenarioAValidatorResponse) as never,
+    });
+    for (let i = 1; i < result.final_hypotheses.length; i++) {
+      expect(result.final_hypotheses[i - 1]!.revised_confidence).toBeGreaterThanOrEqual(
+        result.final_hypotheses[i]!.revised_confidence
+      );
+    }
+  });
+
+  it("investigation has status=completed", async () => {
+    const alert = alertFromScenario("deploy-regression");
+    const result = await runFullInvestigation(alert, {
+      scenario: "deploy-regression",
+      investigationClient: makeSequentialClient(scenarioAResponses) as never,
+      validationClient: makeSingleClient(scenarioAValidatorResponse) as never,
+    });
+    expect(result.investigation.status).toBe("completed");
+  });
+});
+
+// ── Scenario B: upstream-failure ──────────────────────────────────────────
+
+describe("Pipeline — Scenario B (upstream-failure)", () => {
+  it("completes without escalation for high-confidence upstream failure", async () => {
+    const alert = alertFromScenario("upstream-failure");
+    // Reuse scenarioA validator response (high confidence pass-through) for B
+    const result = await runFullInvestigation(alert, {
+      scenario: "upstream-failure",
+      investigationClient: makeSequentialClient(scenarioBResponses) as never,
+      validationClient: makeSingleClient(scenarioAValidatorResponse) as never,
+    });
+    expect(result.investigation.status).toBe("completed");
+    expect(result.final_hypotheses.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Scenario C: escalation ────────────────────────────────────────────────
+
+describe("Pipeline — Scenario C (no-clear-cause)", () => {
+  it("escalates for inconclusive investigation", async () => {
+    const alert = alertFromScenario("no-clear-cause");
+    const result = await runFullInvestigation(alert, {
+      scenario: "no-clear-cause",
+      investigationClient: makeSequentialClient(scenarioCResponses) as never,
+      validationClient: makeSingleClient(scenarioCValidatorResponse) as never,
+    });
+    expect(result.escalate).toBe(true);
+  });
+
+  it("escalation_reason is present when escalating", async () => {
+    const alert = alertFromScenario("no-clear-cause");
+    const result = await runFullInvestigation(alert, {
+      scenario: "no-clear-cause",
+      investigationClient: makeSequentialClient(scenarioCResponses) as never,
+      validationClient: makeSingleClient(scenarioCValidatorResponse) as never,
+    });
+    expect(result.validation.escalation_reason).toBeTruthy();
+  });
+
+  it("final_hypotheses still sorted even with low confidence", async () => {
+    const alert = alertFromScenario("no-clear-cause");
+    const result = await runFullInvestigation(alert, {
+      scenario: "no-clear-cause",
+      investigationClient: makeSequentialClient(scenarioCResponses) as never,
+      validationClient: makeSingleClient(scenarioCValidatorResponse) as never,
+    });
+    for (let i = 1; i < result.final_hypotheses.length; i++) {
+      expect(result.final_hypotheses[i - 1]!.revised_confidence).toBeGreaterThanOrEqual(
+        result.final_hypotheses[i]!.revised_confidence
+      );
+    }
+  });
+});
+
+// ── Schema validation ──────────────────────────────────────────────────────
+
+describe("FullInvestigationResult schema", () => {
+  it("all duration fields are non-negative numbers", async () => {
+    const alert = alertFromScenario("deploy-regression");
+    const result = await runFullInvestigation(alert, {
+      scenario: "deploy-regression",
+      investigationClient: makeSequentialClient(scenarioAResponses) as never,
+      validationClient: makeSingleClient(scenarioAValidatorResponse) as never,
+    });
+    expect(result.investigation_duration_ms).toBeGreaterThanOrEqual(0);
+    expect(result.validation_duration_ms).toBeGreaterThanOrEqual(0);
+    expect(result.total_duration_ms).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/hypothesis-validator/src/index.ts
+++ b/packages/hypothesis-validator/src/index.ts
@@ -1,15 +1,6 @@
-import type { Hypothesis } from "@shared/types";
-
-export class HypothesisValidator {
-  async validate(hypothesis: Hypothesis): Promise<Hypothesis> {
-    // Placeholder: real implementation will query metrics, logs, traces
-    return {
-      ...hypothesis,
-      confidence: hypothesis.confidence,
-    };
-  }
-
-  rankHypotheses(hypotheses: Hypothesis[]): Hypothesis[] {
-    return [...hypotheses].sort((a, b) => b.confidence - a.confidence);
-  }
-}
+// Main entry point — re-export the full pipeline for Slack Bot and other consumers
+export { runFullInvestigation } from "./pipeline";
+export type { FullInvestigationResult, PipelineOptions } from "./pipeline";
+export { validate } from "./validator";
+export type { ValidationResult, ValidatedHypothesis } from "./types";
+export { recalibrateConfidence, shouldEscalate, rerankHypotheses } from "./scoring";

--- a/packages/hypothesis-validator/src/pipeline-cli.ts
+++ b/packages/hypothesis-validator/src/pipeline-cli.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env bun
+import { parseArgs } from "util";
+import { readFileSync } from "fs";
+import type { Alert } from "@shared/types";
+import type { ScenarioName } from "@shared/mock-data";
+import { getScenario, listScenarios } from "@shared/mock-data";
+import { runFullInvestigation } from "./pipeline";
+
+// ── Scenario aliases ───────────────────────────────────────────────────────
+
+const SCENARIO_ALIASES: Record<string, ScenarioName> = {
+  A: "deploy-regression",
+  B: "upstream-failure",
+  C: "no-clear-cause",
+  "deploy-regression": "deploy-regression",
+  "upstream-failure": "upstream-failure",
+  "no-clear-cause": "no-clear-cause",
+};
+
+// ── Parse args ─────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    scenario:    { type: "string",  short: "s" },
+    service:     { type: "string" },
+    severity:    { type: "string" },
+    description: { type: "string" },
+    alert:       { type: "string" },
+    json:        { type: "boolean", default: false },
+    help:        { type: "boolean", short: "h", default: false },
+    "service-graph-url": { type: "string" },
+  },
+  strict: false,
+  allowPositionals: false,
+});
+
+// ── Help ───────────────────────────────────────────────────────────────────
+
+if (values.help || (!values.scenario && !values.service && !values.alert)) {
+  console.log(`
+Usage: bun run investigate [options]
+
+Runs the full pipeline: Investigation Agent → Hypothesis Validator
+
+Options:
+  --scenario, -s <name>    Run a predefined scenario (A, B, C or full name)
+  --service <name>         Service name for a custom alert
+  --severity <level>       Severity: critical | high | medium | low (default: critical)
+  --description <text>     Alert description for a custom alert
+  --alert <path>           Path to a JSON alert file
+  --json                   Output machine-readable JSON instead of pretty print
+  --service-graph-url      Override service-graph API URL (default: http://localhost:3001)
+  --help, -h               Show this help
+
+Available scenarios:
+${listScenarios().map((s) => `  ${s}`).join("\n")}
+
+Examples:
+  bun run investigate --scenario A
+  bun run investigate --scenario B --json
+  bun run investigate --scenario C
+  bun run investigate --service payment-service --description "Error rate spiked to 8%"
+`);
+  process.exit(0);
+}
+
+// ── Build alert ────────────────────────────────────────────────────────────
+
+let alert: Alert;
+let scenario: ScenarioName;
+
+if (values.alert) {
+  try {
+    const raw = JSON.parse(readFileSync(values.alert as string, "utf-8"));
+    alert = { ...raw, timestamp: new Date(raw.timestamp) };
+    scenario = (SCENARIO_ALIASES[values.scenario as string] ?? "deploy-regression") as ScenarioName;
+  } catch (err) {
+    console.error(`❌ Failed to load alert file: ${(err as Error).message}`);
+    process.exit(1);
+  }
+} else if (values.scenario) {
+  const scenarioName = SCENARIO_ALIASES[values.scenario as string];
+  if (!scenarioName) {
+    console.error(`❌ Unknown scenario: ${values.scenario}`);
+    console.error(`   Valid options: ${Object.keys(SCENARIO_ALIASES).join(", ")}`);
+    process.exit(1);
+  }
+  scenario = scenarioName;
+  const s = getScenario(scenario);
+  alert = {
+    id: `alert-${Date.now()}`,
+    title: s.triggerAlert.title,
+    severity: s.triggerAlert.severity,
+    service: s.triggerAlert.service,
+    timestamp: new Date(s.triggerAlert.firedAt),
+    labels: { env: "production", scenario },
+    description: s.description,
+  };
+} else {
+  scenario = (SCENARIO_ALIASES[values.scenario as string ?? ""] ?? "deploy-regression") as ScenarioName;
+  alert = {
+    id: `alert-${Date.now()}`,
+    title: values.description as string ?? `Alert: ${values.service} degraded`,
+    severity: (values.severity as Alert["severity"]) ?? "critical",
+    service: values.service as string ?? "unknown-service",
+    timestamp: new Date(),
+    labels: { env: "production" },
+    description: values.description as string,
+  };
+}
+
+// ── Pretty-print helpers ───────────────────────────────────────────────────
+
+function confidenceBar(n: number): string {
+  return "█".repeat(Math.round(n / 10)) + "░".repeat(10 - Math.round(n / 10));
+}
+
+function printResult(result: Awaited<ReturnType<typeof runFullInvestigation>>) {
+  const { investigation, validation, final_hypotheses } = result;
+
+  if (investigation.status === "failed") {
+    console.log(`\n❌ Investigation failed: ${investigation.summary}`);
+    return;
+  }
+
+  console.log(`\n📊 Pipeline complete`);
+  console.log(`   Investigation: ${result.investigation_duration_ms}ms`);
+  console.log(`   Validation:    ${result.validation_duration_ms}ms`);
+  console.log(`   Total:         ${result.total_duration_ms}ms`);
+  console.log();
+
+  if (investigation.summary) {
+    console.log(`📢 Summary: ${investigation.summary}`);
+    console.log();
+  }
+
+  if (result.escalate) {
+    console.log(`🚨 ESCALATION REQUIRED: ${validation.escalation_reason}`);
+    console.log();
+  }
+
+  if (final_hypotheses.length === 0) {
+    console.log("⚠️  No hypotheses generated.");
+    return;
+  }
+
+  console.log(`🔬 Validated Hypotheses (re-ranked by revised confidence):`);
+  console.log();
+
+  for (const [i, vh] of final_hypotheses.entries()) {
+    const origH = investigation.hypotheses[vh.original_rank - 1];
+    const bar = confidenceBar(vh.revised_confidence);
+    console.log(`Hypothesis ${i + 1} — original: ${vh.original_confidence}% → revised: ${vh.revised_confidence}% [${bar}]`);
+    if (origH) {
+      console.log(`  ${origH.description}`);
+    }
+    if (vh.key_objections.length) {
+      console.log(`  Objections:`);
+      vh.key_objections.forEach((o) => console.log(`    ⚠ ${o}`));
+    }
+    if (origH?.suggestedActions.length) {
+      console.log(`  Action: ${origH.suggestedActions[0]}`);
+    }
+    console.log();
+  }
+
+  console.log(`📝 Validator notes: ${validation.validator_notes}`);
+}
+
+// ── Run ────────────────────────────────────────────────────────────────────
+
+if (!values.json) {
+  const sev = alert.severity.toUpperCase();
+  console.log(`\n🔍 Investigating ${alert.service} (${sev}) with validation...`);
+  console.log(`   Alert: ${alert.title}`);
+  console.log(`   Scenario: ${scenario}`);
+  console.log();
+}
+
+try {
+  const result = await runFullInvestigation(alert, {
+    scenario,
+    serviceGraphUrl: values["service-graph-url"] as string | undefined,
+  });
+
+  if (values.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printResult(result);
+  }
+
+  process.exit(result.escalate || result.investigation.status === "failed" ? 1 : 0);
+} catch (err) {
+  console.error(`\n❌ Fatal error: ${(err as Error).message}`);
+  process.exit(1);
+}

--- a/packages/hypothesis-validator/src/pipeline.ts
+++ b/packages/hypothesis-validator/src/pipeline.ts
@@ -1,0 +1,79 @@
+import type { Alert } from "@shared/types";
+import type { ScenarioName } from "@shared/mock-data";
+import { investigate, type InvestigateOptions } from "@oncall/investigation-agent";
+import { validate, type ValidateOptions } from "./validator";
+import { rerankHypotheses } from "./scoring";
+import type { FullInvestigationResult } from "./types";
+
+export type { FullInvestigationResult } from "./types";
+
+// ── Pipeline options ───────────────────────────────────────────────────────
+
+export interface PipelineOptions {
+  scenario: ScenarioName;
+  serviceGraphUrl?: string;
+  apiKey?: string;
+  /** Inject clients for both phases (used in tests). */
+  investigationClient?: InvestigateOptions["client"];
+  validationClient?: ValidateOptions["client"];
+}
+
+// ── Full investigation pipeline ────────────────────────────────────────────
+
+/**
+ * Run the two-phase pipeline:
+ *   Phase 1 — Investigation Agent: gather evidence, produce hypotheses
+ *   Phase 2 — Hypothesis Validator: adversarially challenge hypotheses
+ *
+ * Returns a FullInvestigationResult with re-ranked final_hypotheses and
+ * per-phase timing. Slack Bot imports this as its main entry point.
+ */
+export async function runFullInvestigation(
+  alert: Alert,
+  opts: PipelineOptions
+): Promise<FullInvestigationResult> {
+  console.log(`\n🚀 Starting full investigation pipeline for alert ${alert.id}`);
+
+  // ── Phase 1: Investigation ───────────────────────────────────────────────
+  console.log(`\nPhase 1: Investigation Agent...`);
+  const t1Start = Date.now();
+
+  const investigation = await investigate(alert, {
+    scenario: opts.scenario,
+    serviceGraphUrl: opts.serviceGraphUrl,
+    apiKey: opts.apiKey,
+    client: opts.investigationClient,
+  });
+
+  const investigation_duration_ms = Date.now() - t1Start;
+  console.log(`   ✓ Phase 1 complete in ${investigation_duration_ms}ms — ${investigation.hypotheses.length} hypothesis(es)`);
+
+  // ── Phase 2: Validation ──────────────────────────────────────────────────
+  console.log(`\nPhase 2: Hypothesis Validator...`);
+  const t2Start = Date.now();
+
+  const validation = await validate(investigation, {
+    apiKey: opts.apiKey,
+    client: opts.validationClient,
+  });
+
+  const validation_duration_ms = Date.now() - t2Start;
+  console.log(`   ✓ Phase 2 complete in ${validation_duration_ms}ms — escalate=${validation.escalate}`);
+
+  // ── Re-rank and assemble ─────────────────────────────────────────────────
+  const final_hypotheses = rerankHypotheses(validation.validated_hypotheses);
+  const total_duration_ms = investigation_duration_ms + validation_duration_ms;
+
+  console.log(`\n✅ Pipeline complete in ${total_duration_ms}ms`);
+
+  return {
+    alert,
+    investigation,
+    validation,
+    final_hypotheses,
+    escalate: validation.escalate,
+    investigation_duration_ms,
+    validation_duration_ms,
+    total_duration_ms,
+  };
+}

--- a/packages/hypothesis-validator/src/types.ts
+++ b/packages/hypothesis-validator/src/types.ts
@@ -1,3 +1,6 @@
+import type { Alert, InvestigationResult } from "@shared/types";
+export type { Alert, InvestigationResult };
+
 // ── Shared types for hypothesis-validator ─────────────────────────────────
 
 export interface ValidatedHypothesis {
@@ -16,4 +19,16 @@ export interface ValidationResult {
   escalate: boolean;
   escalation_reason?: string;
   validator_notes: string;
+}
+
+export interface FullInvestigationResult {
+  alert: Alert;
+  investigation: InvestigationResult;
+  validation: ValidationResult;
+  /** Hypotheses re-ranked by revised_confidence descending */
+  final_hypotheses: ValidatedHypothesis[];
+  escalate: boolean;
+  investigation_duration_ms: number;
+  validation_duration_ms: number;
+  total_duration_ms: number;
 }

--- a/packages/hypothesis-validator/tsconfig.json
+++ b/packages/hypothesis-validator/tsconfig.json
@@ -5,7 +5,8 @@
     "types": ["bun-types"],
     "paths": {
       "@shared/types": ["../../shared/types/index.ts"],
-      "@shared/mock-data": ["../../shared/mock-data/index.ts"]
+      "@shared/mock-data": ["../../shared/mock-data/index.ts"],
+      "@oncall/investigation-agent": ["../investigation-agent/src/agent.ts"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary
- `pipeline.ts`: `runFullInvestigation(alert, opts)` runs Phase 1 (Investigation Agent) then Phase 2 (Hypothesis Validator) in sequence, re-ranks `final_hypotheses` by `revised_confidence` descending, and measures each phase duration independently
- `FullInvestigationResult` type with `investigation_duration_ms`, `validation_duration_ms`, `total_duration_ms`
- `pipeline-cli.ts`: `bun run investigate --scenario A/B/C` runs the full pipeline with a rich pretty-print (original→revised confidence, objections, escalation banner)
- `index.ts` re-exports `runFullInvestigation` as the primary entry point for the Slack Bot (issue #16+)
- Both phases accept injectable clients for deterministic testing

## Test plan
- [x] Scenario A: completes without escalation, final_hypotheses sorted, timing formula holds
- [x] Scenario B: completes, final_hypotheses non-empty
- [x] Scenario C: escalates, escalation_reason present, final_hypotheses sorted
- [x] `total_duration_ms = investigation_duration_ms + validation_duration_ms`
- [x] All duration fields are non-negative numbers
- [x] 51/51 tests pass (`bun test`)
- [x] `tsc --noEmit` clean

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)