### PR TITLE
Add alert parser: LLM extraction with regex fallback for natural language inputs

### DIFF
--- a/packages/slack-bot/package.json
+++ b/packages/slack-bot/package.json
@@ -6,7 +6,8 @@
     "dev": "bun run --watch src/app.ts",
     "start": "bun run src/app.ts",
     "build": "bun build src/app.ts --outdir dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src/__tests__"
   },
   "dependencies": {
     "@shared/types": "workspace:*",

--- a/packages/slack-bot/src/__tests__/alert-parser.test.ts
+++ b/packages/slack-bot/src/__tests__/alert-parser.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, mock } from "bun:test";
+import { parseAlert } from "../alert-parser";
+
+// ── Mock LLM client ────────────────────────────────────────────────────────
+
+function makeLLMClient(extracted: {
+  service?: string;
+  severity?: string;
+  description?: string;
+  started_at?: string | null;
+}) {
+  return {
+    messages: {
+      create: mock(async () => ({
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        model: "claude-haiku-4-5-20251001",
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 100, output_tokens: 40 },
+        content: [{ type: "text", text: JSON.stringify(extracted) }],
+      })),
+    },
+  };
+}
+
+// ── Example inputs from the issue spec ────────────────────────────────────
+
+describe("Issue spec example inputs", () => {
+  it("parses: '@Autoheal payment-service is throwing 500s since the 14:30 deploy'", async () => {
+    const result = await parseAlert(
+      "@Autoheal payment-service is throwing 500s since the 14:30 deploy",
+      {
+        client: makeLLMClient({
+          service: "payment-service",
+          severity: "high",
+          description: "payment-service throwing 500s since the 14:30 deploy",
+          started_at: "2024-01-15T14:30:00.000Z",
+        }) as never,
+      }
+    );
+    expect(result.service).toBe("payment-service");
+    expect(result.severity).toBe("high");
+    expect(result.description).toContain("500s");
+    expect(result.timestamp).toBeInstanceOf(Date);
+  });
+
+  it("parses: '@Autoheal P1: order-service latency spiked 10 minutes ago'", async () => {
+    const result = await parseAlert(
+      "@Autoheal P1: order-service latency spiked 10 minutes ago",
+      {
+        client: makeLLMClient({
+          service: "order-service",
+          severity: "P1",
+          description: "order-service latency spiked 10 minutes ago",
+          started_at: null,
+        }) as never,
+      }
+    );
+    expect(result.service).toBe("order-service");
+    expect(result.severity).toBe("critical");
+  });
+
+  it("parses: '@Autoheal investigate fraud-service — high error rate'", async () => {
+    const result = await parseAlert(
+      "@Autoheal investigate fraud-service — high error rate",
+      {
+        client: makeLLMClient({
+          service: "fraud-service",
+          severity: "high",
+          description: "fraud-service high error rate",
+        }) as never,
+      }
+    );
+    expect(result.service).toBe("fraud-service");
+    expect(result.severity).toBe("high");
+  });
+
+  it("parses: '/investigate service=payment-service severity=P1'", async () => {
+    const result = await parseAlert(
+      "/investigate service=payment-service severity=P1",
+      {
+        client: makeLLMClient({
+          service: "payment-service",
+          severity: "P1",
+          description: "investigate payment-service",
+        }) as never,
+      }
+    );
+    expect(result.service).toBe("payment-service");
+    expect(result.severity).toBe("critical");
+  });
+});
+
+// ── Default values ─────────────────────────────────────────────────────────
+
+describe("Default values for missing fields", () => {
+  it("defaults severity to 'high' (P2) when not specified", async () => {
+    const result = await parseAlert("payment-service is broken", {
+      client: makeLLMClient({
+        service: "payment-service",
+        description: "payment-service is broken",
+      }) as never,
+    });
+    expect(result.severity).toBe("high");
+  });
+
+  it("defaults started_at to now when not specified", async () => {
+    const before = Date.now();
+    const result = await parseAlert("payment-service is down", {
+      client: makeLLMClient({
+        service: "payment-service",
+        description: "payment-service is down",
+      }) as never,
+    });
+    const after = Date.now();
+    expect(result.timestamp.getTime()).toBeGreaterThanOrEqual(before - 100);
+    expect(result.timestamp.getTime()).toBeLessThanOrEqual(after + 100);
+  });
+
+  it("defaults service to 'unknown-service' for garbled input", async () => {
+    const result = await parseAlert("something is very wrong everywhere!!", {
+      client: makeLLMClient({ description: "something is very wrong" }) as never,
+    });
+    expect(result.service).toBe("unknown-service");
+  });
+
+  it("always sets source=slack label", async () => {
+    const result = await parseAlert("payment-service down", {
+      client: makeLLMClient({ service: "payment-service" }) as never,
+    });
+    expect(result.labels.source).toBe("slack");
+  });
+});
+
+// ── Severity normalization ─────────────────────────────────────────────────
+
+describe("Severity normalization", () => {
+  const cases: [string, string][] = [
+    ["P1", "critical"],
+    ["p1", "critical"],
+    ["critical", "critical"],
+    ["P2", "high"],
+    ["high", "high"],
+    ["P3", "medium"],
+    ["medium", "medium"],
+    ["P4", "low"],
+    ["low", "low"],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`maps severity "${input}" → "${expected}"`, async () => {
+      const result = await parseAlert("some-service is down", {
+        client: makeLLMClient({ service: "some-service", severity: input }) as never,
+      });
+      expect(result.severity).toBe(expected as never);
+    });
+  }
+});
+
+// ── Regex fallback (no LLM client) ────────────────────────────────────────
+
+describe("Regex fallback (no LLM client provided)", () => {
+  it("extracts service name via regex", async () => {
+    // No client → regex path; no ANTHROPIC_API_KEY in test env
+    const result = await parseAlert("payment-service is throwing errors", {});
+    expect(result.service).toBe("payment-service");
+  });
+
+  it("extracts P1 severity via regex", async () => {
+    const result = await parseAlert("P1 fraud-service outage", {});
+    expect(result.severity).toBe("critical");
+  });
+
+  it("extracts slash command KV format via regex", async () => {
+    const result = await parseAlert("/investigate service=order-service severity=p2", {});
+    expect(result.service).toBe("order-service");
+    expect(result.severity).toBe("high");
+  });
+
+  it("gracefully returns partial alert for garbled input", async () => {
+    const result = await parseAlert("!@#$% broken stuff everywhere", {});
+    expect(result.id).toMatch(/^slack-/);
+    expect(result.labels.source).toBe("slack");
+    expect(result.rawText).toBe("!@#$% broken stuff everywhere");
+  });
+});
+
+// ── Schema validation ──────────────────────────────────────────────────────
+
+describe("ParsedAlert schema", () => {
+  it("always has required Alert fields", async () => {
+    const result = await parseAlert("payment-service down P1", {
+      client: makeLLMClient({
+        service: "payment-service",
+        severity: "P1",
+        description: "payment-service down",
+      }) as never,
+    });
+    expect(typeof result.id).toBe("string");
+    expect(typeof result.title).toBe("string");
+    expect(["critical", "high", "medium", "low"]).toContain(result.severity);
+    expect(typeof result.service).toBe("string");
+    expect(result.timestamp).toBeInstanceOf(Date);
+    expect(typeof result.labels).toBe("object");
+    expect(typeof result.rawText).toBe("string");
+  });
+
+  it("title is truncated to 200 chars max", async () => {
+    const longDesc = "a".repeat(300);
+    const result = await parseAlert("payment-service " + longDesc, {
+      client: makeLLMClient({
+        service: "payment-service",
+        description: longDesc,
+      }) as never,
+    });
+    expect(result.title.length).toBeLessThanOrEqual(200);
+  });
+
+  it("rawText preserves original input including @mention", async () => {
+    const input = "@Autoheal payment-service is down";
+    const result = await parseAlert(input, {
+      client: makeLLMClient({ service: "payment-service" }) as never,
+    });
+    expect(result.rawText).toBe(input);
+  });
+});

--- a/packages/slack-bot/src/alert-parser.ts
+++ b/packages/slack-bot/src/alert-parser.ts
@@ -1,0 +1,142 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { Alert } from "@shared/types";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface ParsedAlert extends Alert {
+  rawText: string;
+}
+
+export interface ParseOptions {
+  apiKey?: string;
+  /** Inject a pre-configured client (used in tests). */
+  client?: Anthropic;
+}
+
+// ── Severity mapping ───────────────────────────────────────────────────────
+
+const SEVERITY_MAP: Record<string, Alert["severity"]> = {
+  p1: "critical", critical: "critical",
+  p2: "high",     high: "high",
+  p3: "medium",   medium: "medium",
+  p4: "low",      low: "low",
+};
+
+function normalizeSeverity(raw: string | undefined): Alert["severity"] {
+  if (!raw) return "high"; // default P2 → high
+  return SEVERITY_MAP[raw.toLowerCase()] ?? "high";
+}
+
+// ── Regex fallback ─────────────────────────────────────────────────────────
+
+const SERVICE_PATTERN  = /\b([a-z][a-z0-9]*(?:-[a-z0-9]+)*-service)\b/i;
+const SEVERITY_PATTERN = /\b(P[1-4]|critical|high|medium|low)\b/i;
+const TIME_PATTERN     = /\b(\d{1,2}:\d{2})\b|(\d+)\s+minutes?\s+ago/i;
+const KV_PATTERN       = /service=([^\s]+)/i;
+const KV_SEV_PATTERN   = /severity=(p[1-4]|critical|high|medium|low)/i;
+
+function regexFallback(text: string): Partial<RawExtracted> {
+  const kvService  = KV_PATTERN.exec(text);
+  const kvSev      = KV_SEV_PATTERN.exec(text);
+  const service    = kvService?.[1] ?? SERVICE_PATTERN.exec(text)?.[1];
+  const severityRaw = kvSev?.[1] ?? SEVERITY_PATTERN.exec(text)?.[1];
+  const timeMatch  = TIME_PATTERN.exec(text);
+
+  let started_at: string | undefined;
+  if (timeMatch?.[1]) {
+    // HH:MM time — assume today
+    const [h, m] = timeMatch[1].split(":").map(Number);
+    const d = new Date();
+    d.setHours(h!, m!, 0, 0);
+    started_at = d.toISOString();
+  } else if (timeMatch?.[2]) {
+    started_at = new Date(Date.now() - Number(timeMatch[2]) * 60_000).toISOString();
+  }
+
+  return {
+    service: service ?? undefined,
+    severity: severityRaw ?? undefined,
+    description: text.trim(),
+    started_at,
+  };
+}
+
+// ── LLM extraction ─────────────────────────────────────────────────────────
+
+interface RawExtracted {
+  service?: string;
+  severity?: string;
+  description?: string;
+  started_at?: string;
+}
+
+const EXTRACTION_PROMPT = `Extract incident information from the following Slack message.
+Return ONLY a JSON object with these fields:
+- service: string (the affected service name, e.g. "payment-service")
+- severity: string (one of: P1, P2, P3, P4, critical, high, medium, low)
+- description: string (brief incident description, max 200 chars)
+- started_at: string (ISO 8601 if a time was mentioned, else null)
+
+If a field is not present in the message, omit it or set it to null.
+Return JSON only — no markdown, no extra text.`;
+
+async function extractWithLLM(text: string, client: Anthropic): Promise<RawExtracted> {
+  const response = await client.messages.create({
+    model: "claude-haiku-4-5-20251001",
+    max_tokens: 256,
+    messages: [
+      { role: "user", content: `${EXTRACTION_PROMPT}\n\nMessage: "${text}"` },
+    ],
+  });
+
+  const block = response.content.find((b) => b.type === "text");
+  const raw = block && block.type === "text" ? block.text.trim() : "";
+  const cleaned = raw.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "").trim();
+
+  try {
+    return JSON.parse(cleaned) as RawExtracted;
+  } catch {
+    return {};
+  }
+}
+
+// ── Main parseAlert function ───────────────────────────────────────────────
+
+export async function parseAlert(
+  text: string,
+  opts: ParseOptions = {}
+): Promise<ParsedAlert> {
+  // Strip @mention prefix
+  const cleanText = text.replace(/^<@[^>]+>\s*/, "").trim();
+
+  let extracted: RawExtracted = {};
+
+  if (opts.client ?? process.env.ANTHROPIC_API_KEY) {
+    try {
+      const client = opts.client ?? new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+      extracted = await extractWithLLM(cleanText, client);
+    } catch {
+      // fall through to regex
+    }
+  }
+
+  // Merge with regex fallback for any missing fields
+  const regex = regexFallback(cleanText);
+  const service     = extracted.service     ?? regex.service     ?? "unknown-service";
+  const severityRaw = extracted.severity    ?? regex.severity;
+  const description = extracted.description ?? regex.description ?? cleanText;
+  const startedAtRaw = extracted.started_at ?? regex.started_at;
+
+  const startedAt = startedAtRaw ? new Date(startedAtRaw) : new Date();
+
+  return {
+    id: `slack-${Date.now()}`,
+    title: description.slice(0, 200),
+    severity: normalizeSeverity(severityRaw),
+    service,
+    timestamp: startedAt,
+    labels: { env: "production", source: "slack" },
+    description,
+    rawText: text,
+  };
+}

--- a/packages/slack-bot/src/app.ts
+++ b/packages/slack-bot/src/app.ts
@@ -1,5 +1,6 @@
 import { App } from "@slack/bolt";
 import type { ScenarioName } from "@shared/mock-data";
+import { parseAlert } from "./alert-parser";
 
 // ── Environment ────────────────────────────────────────────────────────────
 
@@ -28,8 +29,8 @@ const SCENARIO_KEYWORDS: Record<string, ScenarioName> = {
   "fraud-service":     "no-clear-cause",
 };
 
-function detectScenario(text: string): ScenarioName {
-  const lower = text.toLowerCase();
+function detectScenario(service: string, text: string): ScenarioName {
+  const lower = (service + " " + text).toLowerCase();
   for (const [keyword, scenario] of Object.entries(SCENARIO_KEYWORDS)) {
     if (lower.includes(keyword)) return scenario;
   }
@@ -46,26 +47,20 @@ async function triggerInvestigation(opts: {
 }) {
   const { text, threadTs, channelId, say } = opts;
 
-  const scenario = detectScenario(text);
-  const service = text.match(/([a-z][a-z0-9-]+-service)/i)?.[1] ?? scenario.split("-")[0] + "-service";
+  // Parse the alert using LLM extraction with regex fallback
+  const alert = await parseAlert(text);
+  alert.labels.channel = channelId;
 
-  await say({ text: `🔍 Investigating *${service}*... (scenario: ${scenario})`, thread_ts: threadTs });
+  const scenario = detectScenario(alert.service, text);
+
+  await say({ text: `🔍 Investigating *${alert.service}*... (severity: ${alert.severity})`, thread_ts: threadTs });
 
   // Lazy import to keep startup fast
   const { runFullInvestigation } = await import("@oncall/hypothesis-validator");
-  const alert = {
-    id: `slack-${Date.now()}`,
-    title: text.slice(0, 200),
-    severity: "critical" as const,
-    service,
-    timestamp: new Date(),
-    labels: { env: "production", source: "slack", channel: channelId },
-    description: text,
-  };
 
   try {
     const result = await runFullInvestigation(alert, {
-      scenario,
+      scenario: scenario as ScenarioName,
       serviceGraphUrl: SERVICE_GRAPH_URL,
     });
 


### PR DESCRIPTION
## Summary
- `alert-parser.ts`: `parseAlert(text, opts)` uses `claude-haiku-4-5-20251001` for cheap structured extraction, falling back to regex when no client/API key is available
- Extracts: `service`, `severity`, `description`, `started_at`
- Severity normalization: P1→critical, P2→high, P3→medium, P4→low
- Defaults: severity=high (P2), timestamp=now, service=unknown-service for garbled input
- Handles @mention prefix stripping and `/investigate service=X severity=Y` KV format
- Wired into `app.ts`: replaces ad-hoc regex with `parseAlert()`

## All 4 spec examples parse correctly
| Input | service | severity |
|-------|---------|----------|
| `@Autoheal payment-service is throwing 500s since the 14:30 deploy` | payment-service | high |
| `@Autoheal P1: order-service latency spiked 10 minutes ago` | order-service | critical |
| `@Autoheal investigate fraud-service — high error rate` | fraud-service | high |
| `/investigate service=payment-service severity=P1` | payment-service | critical |

## Test plan
- [x] All 4 spec input examples
- [x] Default severity (high/P2), default timestamp=now
- [x] Garbled input → unknown-service, no crash
- [x] All 9 severity mapping cases (P1–P4 + named)
- [x] Regex fallback (no LLM client)
- [x] Schema validation (required fields, title truncation, rawText preservation)
- [x] 24/24 tests pass, `tsc --noEmit` clean

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)