### PR TITLE
feat(slack-bot): Block Kit formatter for investigation results (#19)

### DIFF
--- a/packages/slack-bot/src/__tests__/formatter.test.ts
+++ b/packages/slack-bot/src/__tests__/formatter.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from "bun:test";
+import {
+  formatDuration,
+  formatInvestigationResult,
+  formatPlainText,
+} from "../formatters/investigation";
+import type { FullInvestigationResult } from "@oncall/hypothesis-validator";
+import type { Alert, InvestigationResult } from "@shared/types";
+import type { ValidationResult } from "@oncall/hypothesis-validator";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const alert: Alert = {
+  id: "alert-1",
+  service: "payment-service",
+  severity: "critical",
+  title: "High error rate",
+  timestamp: new Date("2024-01-15T14:30:00Z"),
+  labels: {},
+};
+
+const investigation: InvestigationResult = {
+  id: "inv-1",
+  alertId: "alert-1",
+  startedAt: new Date("2024-01-15T14:30:00Z"),
+  completedAt: new Date("2024-01-15T14:30:30Z"),
+  status: "completed",
+  hypotheses: [
+    {
+      id: "hyp-1",
+      description: "Deploy abc123 introduced NPE in PaymentProcessor.java:247",
+      confidence: 87,
+      evidence: ["Deploy abc123 at 14:28", "Error rate spike at 14:30", "NPE in logs"],
+      relatedServices: [],
+      suggestedActions: ["Roll back payment-service to v2.4.0", "https://wiki.example.com/rollback"],
+    },
+    {
+      id: "hyp-2",
+      description: "Database connection pool exhausted",
+      confidence: 30,
+      evidence: ["High DB latency"],
+      relatedServices: [],
+      suggestedActions: ["Increase connection pool size"],
+    },
+  ],
+  summary: "Deploy abc123 introduced NPE — recommend rollback",
+};
+
+const validationSuccess: ValidationResult = {
+  incident_id: "inv-1",
+  validated_hypotheses: [
+    {
+      original_rank: 1,
+      original_confidence: 87,
+      challenge_score: 10,
+      key_objections: ["Minor config ambiguity"],
+      missing_evidence: ["Full stack trace"],
+      revised_confidence: 78,
+    },
+    {
+      original_rank: 2,
+      original_confidence: 30,
+      challenge_score: 20,
+      key_objections: [],
+      missing_evidence: [],
+      revised_confidence: 24,
+    },
+  ],
+  escalate: false,
+  escalation_reason: undefined,
+  validator_notes: "Evidence chain is solid. Deploy timing is clear.",
+};
+
+const validationEscalate: ValidationResult = {
+  incident_id: "inv-1",
+  validated_hypotheses: [
+    {
+      original_rank: 1,
+      original_confidence: 87,
+      challenge_score: 80,
+      key_objections: ["o1", "o2", "o3", "o4"],
+      missing_evidence: ["many things"],
+      revised_confidence: 17,
+    },
+  ],
+  escalate: true,
+  escalation_reason: "All hypotheses heavily challenged, confidence too low",
+  validator_notes: "Unable to confirm root cause. Human review required.",
+};
+
+function makeResult(validation: ValidationResult): FullInvestigationResult {
+  const { rerankHypotheses } = require("@oncall/hypothesis-validator") as typeof import("@oncall/hypothesis-validator");
+  const final_hypotheses = rerankHypotheses(validation.validated_hypotheses);
+  return {
+    alert,
+    investigation,
+    validation,
+    final_hypotheses,
+    escalate: validation.escalate,
+    investigation_duration_ms: 28_000,
+    validation_duration_ms: 4_500,
+    total_duration_ms: 32_500,
+  };
+}
+
+// ── formatDuration ─────────────────────────────────────────────────────────
+
+describe("formatDuration", () => {
+  it("shows ms for sub-second durations", () => {
+    expect(formatDuration(0)).toBe("0ms");
+    expect(formatDuration(500)).toBe("500ms");
+    expect(formatDuration(999)).toBe("999ms");
+  });
+
+  it("shows seconds with one decimal for ≥1000ms", () => {
+    expect(formatDuration(1000)).toBe("1.0s");
+    expect(formatDuration(32_500)).toBe("32.5s");
+    expect(formatDuration(60_000)).toBe("60.0s");
+  });
+});
+
+// ── formatInvestigationResult — success path ───────────────────────────────
+
+describe("formatInvestigationResult — success path", () => {
+  const result = makeResult(validationSuccess);
+  const blocks = formatInvestigationResult(result);
+
+  it("first block is a header containing the service name", () => {
+    const header = blocks[0];
+    expect(header.type).toBe("header");
+    if (header.type === "header") {
+      expect(header.text.text).toContain("payment-service");
+    }
+  });
+
+  it("contains a meta line with duration, severity, and status", () => {
+    const metaBlock = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text.text.includes("Duration:")
+    );
+    expect(metaBlock).toBeDefined();
+    if (metaBlock && metaBlock.type === "section") {
+      expect(metaBlock.text.text).toContain("CRITICAL");
+      expect(metaBlock.text.text).toContain("32.5s");
+    }
+  });
+
+  it("does NOT include an escalation banner", () => {
+    const escalationBlock = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text.text.includes("Escalation required")
+    );
+    expect(escalationBlock).toBeUndefined();
+  });
+
+  it("contains the investigation summary", () => {
+    const summaryBlock = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text.text.includes("Deploy abc123")
+    );
+    expect(summaryBlock).toBeDefined();
+  });
+
+  it("includes hypothesis confidence original→revised", () => {
+    const hypBlock = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text.text.includes("87%") && b.text.text.includes("78%")
+    );
+    expect(hypBlock).toBeDefined();
+  });
+
+  it("includes action buttons with correct action_ids", () => {
+    const actionsBlock = blocks.find((b) => b.type === "actions");
+    expect(actionsBlock).toBeDefined();
+    if (actionsBlock && actionsBlock.type === "actions") {
+      const ids = actionsBlock.elements.map((e) => e.action_id);
+      expect(ids).toContain("hypothesis_confirm");
+      expect(ids).toContain("hypothesis_reject");
+      expect(ids).toContain("investigate_more");
+    }
+  });
+
+  it("includes validator notes in a context block", () => {
+    const contextBlock = blocks.find(
+      (b) => b.type === "context" && "elements" in b &&
+        b.elements.some((e) => "text" in e && e.text.includes("Evidence chain is solid"))
+    );
+    expect(contextBlock).toBeDefined();
+  });
+});
+
+// ── formatInvestigationResult — evidence truncation ────────────────────────
+
+describe("formatInvestigationResult — evidence truncation", () => {
+  it("shows at most 5 evidence items with overflow note", () => {
+    const longEvidence = ["e1", "e2", "e3", "e4", "e5", "e6", "e7"];
+    const richInvestigation: InvestigationResult = {
+      ...investigation,
+      hypotheses: [{
+        ...investigation.hypotheses[0]!,
+        evidence: longEvidence,
+      }, ...investigation.hypotheses.slice(1)],
+    };
+    const result: FullInvestigationResult = {
+      ...makeResult(validationSuccess),
+      investigation: richInvestigation,
+    };
+    const blocks = formatInvestigationResult(result);
+
+    const evidenceBlock = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text.text.includes("Evidence:")
+    );
+    expect(evidenceBlock).toBeDefined();
+    if (evidenceBlock && evidenceBlock.type === "section") {
+      // 5 bullets + overflow note
+      expect(evidenceBlock.text.text).toContain("…and 2 more");
+      // Exactly 5 bullets
+      const bulletCount = (evidenceBlock.text.text.match(/^• /gm) ?? []).length;
+      expect(bulletCount).toBe(5);
+    }
+  });
+});
+
+// ── formatInvestigationResult — escalation path ────────────────────────────
+
+describe("formatInvestigationResult — escalation path", () => {
+  const result = makeResult(validationEscalate);
+  const blocks = formatInvestigationResult(result);
+
+  it("includes an escalation banner with the reason", () => {
+    const banner = blocks.find(
+      (b) => b.type === "section" && "text" in b && b.text.text.includes("Escalation required")
+    );
+    expect(banner).toBeDefined();
+    if (banner && banner.type === "section") {
+      expect(banner.text.text).toContain("All hypotheses heavily challenged");
+    }
+  });
+
+  it("does NOT include action buttons when escalating", () => {
+    const actionsBlock = blocks.find((b) => b.type === "actions");
+    expect(actionsBlock).toBeUndefined();
+  });
+});
+
+// ── formatPlainText ────────────────────────────────────────────────────────
+
+describe("formatPlainText", () => {
+  it("returns plain text summary for success path", () => {
+    const result = makeResult(validationSuccess);
+    const text = formatPlainText(result);
+    expect(text).toContain("Deploy abc123");
+    expect(text).toContain("78%");
+  });
+
+  it("returns escalation message when escalating", () => {
+    const result = makeResult(validationEscalate);
+    const text = formatPlainText(result);
+    expect(text).toContain("⚠️");
+    expect(text).toContain("All hypotheses heavily challenged");
+  });
+});

--- a/packages/slack-bot/src/formatters/investigation.ts
+++ b/packages/slack-bot/src/formatters/investigation.ts
@@ -1,0 +1,231 @@
+import type { FullInvestigationResult, ValidatedHypothesis } from "@oncall/hypothesis-validator";
+import type { InvestigationResult, Hypothesis } from "@shared/types";
+
+// ── Slack Block Kit types (minimal) ───────────────────────────────────────
+
+export interface TextObject {
+  type: "plain_text" | "mrkdwn";
+  text: string;
+  emoji?: boolean;
+}
+
+export interface HeaderBlock  { type: "header";  text: TextObject }
+export interface DividerBlock { type: "divider" }
+export interface SectionBlock { type: "section"; text: TextObject; accessory?: unknown }
+export interface ContextBlock { type: "context"; elements: TextObject[] }
+export interface ActionsBlock {
+  type: "actions";
+  elements: Array<{
+    type: "button";
+    text: TextObject;
+    value: string;
+    action_id: string;
+    style?: "primary" | "danger";
+  }>;
+}
+
+export type Block = HeaderBlock | DividerBlock | SectionBlock | ContextBlock | ActionsBlock;
+
+// ── Duration formatter ─────────────────────────────────────────────────────
+
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// ── Confidence bar ─────────────────────────────────────────────────────────
+
+function confidenceEmoji(pct: number): string {
+  if (pct >= 80) return "🟢";
+  if (pct >= 50) return "🟡";
+  return "🔴";
+}
+
+// ── Evidence bullets ───────────────────────────────────────────────────────
+
+const MAX_EVIDENCE = 5;
+
+function formatEvidence(evidence: string[]): string {
+  if (!evidence.length) return "_No specific evidence cited._";
+  const shown = evidence.slice(0, MAX_EVIDENCE);
+  const rest  = evidence.length - shown.length;
+  const lines = shown.map((e) => `• ${e}`);
+  if (rest > 0) lines.push(`_…and ${rest} more_`);
+  return lines.join("\n");
+}
+
+// ── Hypothesis block builder ──────────────────────────────────────────────
+
+function hypothesisBlocks(
+  vh: ValidatedHypothesis,
+  origH: Hypothesis | undefined,
+  rank: number,
+  isTop: boolean
+): Block[] {
+  const conf = vh.revised_confidence;
+  const emoji = confidenceEmoji(conf);
+  const label = isTop ? `*Hypothesis #${rank}* ${emoji}` : `Hypothesis #${rank} ${emoji}`;
+  const header = `${label} · Confidence: *${vh.original_confidence}%* → *${conf}%* _(challenge: ${vh.challenge_score}/100)_`;
+  const desc   = origH?.description ?? "No description available";
+
+  const blocks: Block[] = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `${header}\n>${desc}` },
+    },
+  ];
+
+  if (isTop && origH?.evidence.length) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*Evidence:*\n${formatEvidence(origH.evidence)}` },
+    });
+  }
+
+  if (isTop && vh.key_objections.length) {
+    blocks.push({
+      type: "context",
+      elements: [{
+        type: "mrkdwn",
+        text: `🔬 *Adversarial check:* ${vh.key_objections[0]}`,
+      }],
+    });
+  }
+
+  if (isTop && origH?.suggestedActions.length) {
+    const runbook = origH.suggestedActions.find((a) => a.startsWith("http"));
+    const action  = origH.suggestedActions.find((a) => !a.startsWith("http"));
+    if (action) {
+      blocks.push({
+        type: "section",
+        text: { type: "mrkdwn", text: `*Suggested action:* ${action}${runbook ? `\n*Runbook:* <${runbook}|docs>` : ""}` },
+      });
+    }
+  }
+
+  return blocks;
+}
+
+// ── Main formatter ─────────────────────────────────────────────────────────
+
+export function formatInvestigationResult(result: FullInvestigationResult): Block[] {
+  const { alert, investigation, validation, final_hypotheses, escalate, total_duration_ms } = result;
+  const blocks: Block[] = [];
+
+  // Header
+  blocks.push({
+    type: "header",
+    text: { type: "plain_text", text: `📊 Investigation: ${alert.service}`, emoji: true },
+  });
+
+  // Meta line
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `*Duration:* ${formatDuration(total_duration_ms)}  ·  *Severity:* ${alert.severity.toUpperCase()}  ·  *Status:* ${investigation.status}`,
+    },
+  });
+
+  // Escalation banner
+  if (escalate) {
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `⚠️ *Escalation required* — ${validation.escalation_reason ?? "Low-confidence investigation. Human review needed."}`,
+      },
+    });
+  }
+
+  // Summary
+  if (investigation.summary) {
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `📢 ${investigation.summary}` },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+
+  // Hypotheses
+  if (final_hypotheses.length === 0) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: "_No hypotheses generated._" },
+    });
+  } else {
+    final_hypotheses.forEach((vh, i) => {
+      const origH = investigation.hypotheses[vh.original_rank - 1];
+      const isTop = i === 0;
+      blocks.push(...hypothesisBlocks(vh, origH, i + 1, isTop));
+      if (i < final_hypotheses.length - 1) blocks.push({ type: "divider" });
+    });
+  }
+
+  // Validator notes
+  if (validation.validator_notes) {
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: `🔬 _${validation.validator_notes}_` }],
+    });
+  }
+
+  // Action buttons (only when not escalating — escalation means human takes over)
+  if (!escalate && final_hypotheses.length > 0) {
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "👍 Correct", emoji: true },
+          value: "confirm",
+          action_id: "hypothesis_confirm",
+          style: "primary",
+        },
+        {
+          type: "button",
+          text: { type: "plain_text", text: "❌ Wrong", emoji: true },
+          value: "reject",
+          action_id: "hypothesis_reject",
+          style: "danger",
+        },
+        {
+          type: "button",
+          text: { type: "plain_text", text: "🔍 Dig deeper", emoji: true },
+          value: "investigate_more",
+          action_id: "investigate_more",
+        },
+      ],
+    });
+  }
+
+  return blocks;
+}
+
+// ── Escalation-only formatter (for status message updates) ─────────────────
+
+export function formatEscalationBlocks(result: FullInvestigationResult): Block[] {
+  return formatInvestigationResult(result);
+}
+
+// ── Plain-text fallback (for notifications/unfurls) ───────────────────────
+
+export function formatPlainText(result: FullInvestigationResult): string {
+  const top = result.final_hypotheses[0];
+  const origH = top ? result.investigation.hypotheses[top.original_rank - 1] : undefined;
+
+  if (result.escalate) {
+    return `⚠️ Escalation required: ${result.validation.escalation_reason ?? "low confidence"}\n${result.investigation.summary ?? ""}`;
+  }
+
+  return [
+    result.investigation.summary ?? `Investigation complete for ${result.alert.service}`,
+    origH ? `Root cause (${top!.revised_confidence}% confidence): ${origH.description}` : "",
+    origH?.suggestedActions[0] ? `Action: ${origH.suggestedActions[0]}` : "",
+  ].filter(Boolean).join("\n");
+}

--- a/packages/slack-bot/src/handlers/incident.ts
+++ b/packages/slack-bot/src/handlers/incident.ts
@@ -1,6 +1,8 @@
 import type { App } from "@slack/bolt";
 import type { ScenarioName } from "@shared/mock-data";
 import { parseAlert } from "../alert-parser";
+import { formatInvestigationResult, formatPlainText } from "../formatters/investigation";
+import type { FullInvestigationResult } from "@oncall/hypothesis-validator";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyAnthropicClient = any;
 
@@ -80,6 +82,7 @@ export async function handleIncident(opts: HandleIncidentOptions): Promise<void>
 
   // 3. Run investigation with live progress updates
   const completedTools: string[] = [];
+  const investigationStart = Date.now();
 
   let investigation;
   try {
@@ -101,6 +104,8 @@ export async function handleIncident(opts: HandleIncidentOptions): Promise<void>
     return;
   }
 
+  const investigationDurationMs = Date.now() - investigationStart;
+
   if (investigation.status === "failed") {
     await safeUpdate(app, channelId, statusTs,
       `❌ Investigation failed: ${investigation.summary ?? "unknown error"}\n_Please investigate manually._`);
@@ -111,6 +116,7 @@ export async function handleIncident(opts: HandleIncidentOptions): Promise<void>
   await safeUpdate(app, channelId, statusTs,
     `🧪 Validating hypotheses...\n${completedTools.map((t) => `✓ ${t}`).join("\n")}`);
 
+  const validationStart = Date.now();
   let validation;
   try {
     const { validate } = await import("@oncall/hypothesis-validator");
@@ -121,74 +127,36 @@ export async function handleIncident(opts: HandleIncidentOptions): Promise<void>
     return;
   }
 
-  // 5. Post final result
+  const validationDurationMs = Date.now() - validationStart;
+
+  // 5. Post final result using Block Kit
   const { rerankHypotheses } = await import("@oncall/hypothesis-validator");
   const finalHypotheses = rerankHypotheses(validation.validated_hypotheses);
-  const top = finalHypotheses[0];
-  const topOriginal = top ? investigation.hypotheses[top.original_rank - 1] : undefined;
+
+  const fullResult: FullInvestigationResult = {
+    alert,
+    investigation,
+    validation,
+    final_hypotheses: finalHypotheses,
+    escalate: validation.escalate,
+    investigation_duration_ms: investigationDurationMs,
+    validation_duration_ms: validationDurationMs,
+    total_duration_ms: investigationDurationMs + validationDurationMs,
+  };
 
   if (validation.escalate) {
     await safeUpdate(app, channelId, statusTs,
       `🚨 *Escalation required* — ${validation.escalation_reason ?? "low confidence investigation"}`);
-    await app.client.chat.postMessage({
-      channel: channelId,
-      thread_ts: threadTs,
-      text: formatEscalationResult(investigation.summary, finalHypotheses, investigation, validation.validator_notes),
-    });
   } else {
     await safeUpdate(app, channelId, statusTs, `✅ *Investigation complete*`);
-    await app.client.chat.postMessage({
-      channel: channelId,
-      thread_ts: threadTs,
-      text: formatSuccessResult(top, topOriginal, investigation.summary, validation.validator_notes),
-    });
   }
-}
 
-// ── Formatters ─────────────────────────────────────────────────────────────
-
-function confidenceBar(n: number): string {
-  return "█".repeat(Math.round(n / 10)) + "░".repeat(10 - Math.round(n / 10));
-}
-
-function formatSuccessResult(
-  top: ReturnType<typeof import("@oncall/hypothesis-validator").rerankHypotheses>[number] | undefined,
-  topOriginal: import("@shared/types").Hypothesis | undefined,
-  summary: string | undefined,
-  validatorNotes: string
-): string {
-  const conf = top?.revised_confidence ?? 0;
-  const bar = confidenceBar(conf);
-  const lines = [
-    summary ? `📢 ${summary}` : "",
-    "",
-    `*Root cause* (${conf}% confidence) \`${bar}\``,
-    topOriginal ? `>${topOriginal.description}` : "",
-    "",
-    topOriginal?.suggestedActions[0] ? `*Action:* ${topOriginal.suggestedActions[0]}` : "",
-    "",
-    `_🔬 ${validatorNotes}_`,
-  ];
-  return lines.filter((l) => l !== "").join("\n");
-}
-
-function formatEscalationResult(
-  summary: string | undefined,
-  finalHypotheses: ReturnType<typeof import("@oncall/hypothesis-validator").rerankHypotheses>,
-  investigation: import("@shared/types").InvestigationResult,
-  validatorNotes: string
-): string {
-  const lines: string[] = [
-    summary ? `📢 ${summary}` : "",
-    "",
-    "*Hypotheses (low confidence — human review needed):*",
-  ];
-  for (const vh of finalHypotheses.slice(0, 3)) {
-    const orig = investigation.hypotheses[vh.original_rank - 1];
-    lines.push(`• ${orig?.description ?? "unknown"} _(${vh.revised_confidence}% revised)_`);
-  }
-  lines.push("", `_🔬 ${validatorNotes}_`);
-  return lines.filter((l) => l !== "").join("\n");
+  await app.client.chat.postMessage({
+    channel: channelId,
+    thread_ts: threadTs,
+    text: formatPlainText(fullResult),
+    blocks: formatInvestigationResult(fullResult),
+  });
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `packages/slack-bot/src/formatters/investigation.ts` with full Slack Block Kit output: header, meta line (duration/severity/status), ⚠️ escalation banner, per-hypothesis blocks with confidence original→revised delta, evidence bullets (truncated at 5), adversarial objection context, suggested action + runbook link, validator notes, and 👍/❌/🔍 action buttons
- Replaces inline plain-text formatters in `incident.ts` with `formatInvestigationResult` (blocks) + `formatPlainText` (fallback for notifications/unfurls)
- Tracks `investigation_duration_ms` and `validation_duration_ms` timestamps to populate `FullInvestigationResult`
- Action buttons only shown on non-escalation paths (escalation means human takes over)

## Test plan

- [x] 14 new unit tests in `formatter.test.ts` covering: `formatDuration` (ms/s), success block structure, meta line content, no escalation banner in success, hypothesis confidence delta, action button `action_id` values, validator notes in context block, evidence truncation at 5 with overflow count, escalation banner with reason, no action buttons on escalation, `formatPlainText` success and escalation paths
- [x] All 48 slack-bot tests pass (`bun test packages/slack-bot`)
- [x] TypeScript typecheck clean (`bun run typecheck`)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)