### PR TITLE
feat(slack-bot): action button handlers — confirm, reject, dig deeper (#20)

### DIFF
--- a/packages/investigation-agent/src/agent.ts
+++ b/packages/investigation-agent/src/agent.ts
@@ -141,6 +141,10 @@ export interface InvestigateOptions {
   client?: Anthropic;
   /** Called after each batch of tool calls completes (for progress notifications). */
   onToolCall?: (toolNames: string[]) => Promise<void>;
+  /** Override the default iteration limit (default: 10). */
+  maxIterations?: number;
+  /** Extra context prepended to the investigation prompt (e.g. previous findings). */
+  contextHint?: string;
 }
 
 export async function investigate(
@@ -148,6 +152,7 @@ export async function investigate(
   opts: InvestigateOptions
 ): Promise<InvestigationResult> {
   const startedAt = new Date();
+  const maxIter = opts.maxIterations ?? MAX_ITERATIONS;
   const deadline = startedAt.getTime() + TIMEOUT_MS;
 
   const anthropic = opts.client ?? new Anthropic({
@@ -159,13 +164,17 @@ export async function investigate(
     serviceGraphUrl: opts.serviceGraphUrl,
   };
 
+  const alertMsg = opts.contextHint
+    ? `${opts.contextHint}\n\n${formatAlertMessage(alert, opts.scenario)}`
+    : formatAlertMessage(alert, opts.scenario);
+
   const messages: MessageParam[] = [
-    { role: "user", content: formatAlertMessage(alert, opts.scenario) },
+    { role: "user", content: alertMsg },
   ];
 
   console.log(`\n🔍 Starting investigation for alert ${alert.id} (scenario: ${opts.scenario})`);
 
-  for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+  for (let iteration = 1; iteration <= maxIter; iteration++) {
     if (Date.now() > deadline) {
       console.warn(`⚠️  Timeout reached after ${iteration - 1} iterations`);
       return {
@@ -249,6 +258,6 @@ export async function investigate(
     completedAt: new Date(),
     status: "failed",
     hypotheses: [],
-    summary: `Investigation exceeded max iterations (${MAX_ITERATIONS})`,
+    summary: `Investigation exceeded max iterations (${maxIter})`,
   };
 }

--- a/packages/slack-bot/src/__tests__/actions.test.ts
+++ b/packages/slack-bot/src/__tests__/actions.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { investigationStore, pendingRejections, registerActionHandlers } from "../handlers/actions";
+import type { FullInvestigationResult } from "@oncall/hypothesis-validator";
+import type { Alert, InvestigationResult } from "@shared/types";
+import type { App } from "@slack/bolt";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const alert: Alert = {
+  id: "alert-test",
+  service: "payment-service",
+  severity: "critical",
+  title: "High error rate",
+  timestamp: new Date("2024-01-15T14:30:00Z"),
+  labels: {},
+};
+
+const investigation: InvestigationResult = {
+  id: "inv-test",
+  alertId: "alert-test",
+  startedAt: new Date("2024-01-15T14:30:00Z"),
+  completedAt: new Date("2024-01-15T14:30:30Z"),
+  status: "completed",
+  hypotheses: [{
+    id: "hyp-1",
+    description: "Deploy abc123 caused NPE",
+    confidence: 87,
+    evidence: ["Deploy at 14:28", "NPE in logs"],
+    relatedServices: [],
+    suggestedActions: ["Roll back to v2.4.0"],
+  }],
+  summary: "Deploy abc123 — recommend rollback",
+  rootCause: "Deploy abc123 caused NPE",
+  resolution: "Roll back to v2.4.0",
+};
+
+function makeFullResult(escalate = false): FullInvestigationResult {
+  return {
+    alert,
+    investigation,
+    validation: {
+      incident_id: "inv-test",
+      validated_hypotheses: [{
+        original_rank: 1,
+        original_confidence: 87,
+        challenge_score: 10,
+        key_objections: ["Minor ambiguity"],
+        missing_evidence: [],
+        revised_confidence: 78,
+      }],
+      escalate,
+      validator_notes: "Evidence is solid.",
+    },
+    final_hypotheses: [{
+      original_rank: 1,
+      original_confidence: 87,
+      challenge_score: 10,
+      key_objections: ["Minor ambiguity"],
+      missing_evidence: [],
+      revised_confidence: 78,
+    }],
+    escalate,
+    investigation_duration_ms: 28_000,
+    validation_duration_ms: 4_500,
+    total_duration_ms: 32_500,
+  };
+}
+
+// ── Mock App factory ───────────────────────────────────────────────────────
+
+function makeActionBody(actionId: string, messageTs = "ts-999", threadTs = "ts-root") {
+  return {
+    container: { channel_id: "C123", message_ts: messageTs },
+    message: {
+      ts: messageTs,
+      thread_ts: threadTs,
+      blocks: [
+        { type: "header", text: { type: "plain_text", text: "Investigation" } },
+        {
+          type: "actions",
+          elements: [{
+            type: "button", text: { type: "plain_text", text: "👍 Correct" },
+            value: "confirm", action_id: "hypothesis_confirm",
+          }],
+        },
+      ],
+    },
+    action: { action_id: actionId },
+    user: { id: "U123" },
+  };
+}
+
+type MockClient = {
+  chat: {
+    postMessage: ReturnType<typeof mock>;
+    update: ReturnType<typeof mock>;
+  };
+};
+
+function makeClient(): MockClient {
+  return {
+    chat: {
+      postMessage: mock(async (args: { text: string }) => ({ ts: `ts-${Date.now()}`, ok: true, text: args.text })),
+      update: mock(async () => ({ ok: true })),
+    },
+  };
+}
+
+// Capture registered action handlers
+type ActionHandler = (ctx: { ack: () => Promise<void>; body: unknown; client: MockClient }) => Promise<void>;
+const actionHandlers: Record<string, ActionHandler> = {};
+
+function makeApp(): App {
+  return {
+    action: (actionId: string, handler: ActionHandler) => {
+      actionHandlers[actionId] = handler;
+    },
+    client: makeClient(),
+  } as unknown as App;
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+let app: App;
+
+beforeEach(() => {
+  investigationStore.clear();
+  pendingRejections.clear();
+  app = makeApp();
+  registerActionHandlers(app);
+});
+
+// ── hypothesis_confirm ─────────────────────────────────────────────────────
+
+describe("hypothesis_confirm", () => {
+  it("acks immediately", async () => {
+    const ack = mock(async () => {});
+    const client = makeClient();
+    investigationStore.set("C123-ts-999", makeFullResult());
+
+    await actionHandlers["hypothesis_confirm"]!({
+      ack, body: makeActionBody("hypothesis_confirm"), client,
+    });
+    expect(ack.mock.calls.length).toBe(1);
+  });
+
+  it("posts a confirmation message in thread", async () => {
+    const client = makeClient();
+    investigationStore.set("C123-ts-999", makeFullResult());
+
+    await actionHandlers["hypothesis_confirm"]!({
+      ack: mock(async () => {}),
+      body: makeActionBody("hypothesis_confirm"),
+      client,
+    });
+
+    const postCalls = client.chat.postMessage.mock.calls as Array<[{ text: string; thread_ts: string }]>;
+    expect(postCalls.length).toBeGreaterThanOrEqual(1);
+    const confirmMsg = postCalls[0]![0];
+    expect(confirmMsg.text).toContain("✅");
+    expect(confirmMsg.thread_ts).toBe("ts-root");
+  });
+
+  it("updates original message to remove action buttons", async () => {
+    const client = makeClient();
+    investigationStore.set("C123-ts-999", makeFullResult());
+
+    await actionHandlers["hypothesis_confirm"]!({
+      ack: mock(async () => {}),
+      body: makeActionBody("hypothesis_confirm"),
+      client,
+    });
+
+    const updateCalls = client.chat.update.mock.calls as Array<[{ blocks: Array<{ type: string }> }]>;
+    expect(updateCalls.length).toBeGreaterThanOrEqual(1);
+    const updatedBlocks = updateCalls[0]![0].blocks;
+    expect(updatedBlocks.some((b) => b.type === "actions")).toBe(false);
+    // Should have a context block with "Confirmed"
+    const contextBlock = updatedBlocks.find((b) => b.type === "context") as { type: "context"; elements: Array<{ text: string }> } | undefined;
+    expect(contextBlock).toBeDefined();
+    expect(contextBlock?.elements[0]?.text).toContain("Confirmed");
+  });
+});
+
+// ── hypothesis_reject ─────────────────────────────────────────────────────
+
+describe("hypothesis_reject", () => {
+  it("posts a prompt asking for the real root cause", async () => {
+    const client = makeClient();
+    investigationStore.set("C123-ts-999", makeFullResult());
+
+    await actionHandlers["hypothesis_reject"]!({
+      ack: mock(async () => {}),
+      body: makeActionBody("hypothesis_reject"),
+      client,
+    });
+
+    const postCalls = client.chat.postMessage.mock.calls as Array<[{ text: string }]>;
+    const promptMsg = postCalls[0]![0];
+    expect(promptMsg.text).toContain("root cause");
+    expect(promptMsg.text).toContain("Reply");
+  });
+
+  it("registers a pending rejection for the thread", async () => {
+    const client = makeClient();
+    investigationStore.set("C123-ts-999", makeFullResult());
+
+    await actionHandlers["hypothesis_reject"]!({
+      ack: mock(async () => {}),
+      body: makeActionBody("hypothesis_reject"),
+      client,
+    });
+
+    expect(pendingRejections.has("C123-ts-root")).toBe(true);
+    expect(pendingRejections.get("C123-ts-root")?.service).toBe("payment-service");
+  });
+
+  it("updates original message to remove action buttons and show rejected state", async () => {
+    const client = makeClient();
+    investigationStore.set("C123-ts-999", makeFullResult());
+
+    await actionHandlers["hypothesis_reject"]!({
+      ack: mock(async () => {}),
+      body: makeActionBody("hypothesis_reject"),
+      client,
+    });
+
+    const updateCalls = client.chat.update.mock.calls as Array<[{ blocks: Array<{ type: string }> }]>;
+    expect(updateCalls.length).toBeGreaterThanOrEqual(1);
+    const updatedBlocks = updateCalls[0]![0].blocks;
+    expect(updatedBlocks.some((b) => b.type === "actions")).toBe(false);
+    const contextBlock = updatedBlocks.find((b) => b.type === "context") as { type: "context"; elements: Array<{ text: string }> } | undefined;
+    expect(contextBlock?.elements[0]?.text).toContain("Rejected");
+  });
+});
+
+// ── investigate_more ──────────────────────────────────────────────────────
+
+describe("investigate_more — no context found", () => {
+  it("posts error message when investigation context is missing", async () => {
+    const client = makeClient();
+    // Do NOT seed investigationStore
+
+    await actionHandlers["investigate_more"]!({
+      ack: mock(async () => {}),
+      body: makeActionBody("investigate_more"),
+      client,
+    });
+
+    const postCalls = client.chat.postMessage.mock.calls as Array<[{ text: string }]>;
+    expect(postCalls.some((c) => c[0].text.includes("❌"))).toBe(true);
+  });
+});
+
+// ── pendingRejections store ────────────────────────────────────────────────
+
+describe("pendingRejections store", () => {
+  it("clears the pending entry after handling (simulated)", () => {
+    pendingRejections.set("C123-ts-thread", { service: "payment-service", alertId: "a1" });
+    expect(pendingRejections.has("C123-ts-thread")).toBe(true);
+    pendingRejections.delete("C123-ts-thread");
+    expect(pendingRejections.has("C123-ts-thread")).toBe(false);
+  });
+});

--- a/packages/slack-bot/src/app.ts
+++ b/packages/slack-bot/src/app.ts
@@ -1,5 +1,6 @@
 import { App } from "@slack/bolt";
 import { handleIncident } from "./handlers/incident";
+import { registerActionHandlers, handlePendingRejection, pendingRejections } from "./handlers/actions";
 
 // ── Environment ────────────────────────────────────────────────────────────
 
@@ -41,6 +42,24 @@ app.event("app_mention", async ({ event }) => {
     app,
     serviceGraphUrl: SERVICE_GRAPH_URL,
   });
+});
+
+// ── Action handlers (button interactions) ─────────────────────────────────
+
+registerActionHandlers(app);
+
+// ── Thread message listener (rejection correction flow) ────────────────────
+
+app.message(async ({ message, client }) => {
+  // Only handle threaded messages that are not from bots
+  if (message.subtype) return; // bot messages, edits, etc.
+  const msg = message as { channel: string; ts: string; thread_ts?: string; text?: string; user?: string };
+  if (!msg.thread_ts || !msg.text) return;
+
+  const key = `${msg.channel}-${msg.thread_ts}`;
+  if (!pendingRejections.has(key)) return;
+
+  await handlePendingRejection(app, msg.channel, msg.thread_ts, msg.text, msg.user ?? "unknown");
 });
 
 // ── Command: /investigate ──────────────────────────────────────────────────

--- a/packages/slack-bot/src/handlers/actions.ts
+++ b/packages/slack-bot/src/handlers/actions.ts
@@ -1,0 +1,379 @@
+import type { App } from "@slack/bolt";
+import type { FullInvestigationResult } from "@oncall/hypothesis-validator";
+import type { Block } from "../formatters/investigation";
+import { formatInvestigationResult, formatPlainText } from "../formatters/investigation";
+
+// ── In-memory stores ───────────────────────────────────────────────────────
+
+/**
+ * Maps `${channel}-${messageTs}` → FullInvestigationResult so action
+ * handlers can access the original investigation context.
+ */
+export const investigationStore = new Map<string, FullInvestigationResult>();
+
+/**
+ * Maps `${channel}-${threadTs}` → service name for pending rejection flows.
+ * When set, the next message in that thread is treated as the correction.
+ */
+export const pendingRejections = new Map<string, { service: string; alertId: string }>();
+
+// ── Button-disable helper ──────────────────────────────────────────────────
+
+/**
+ * Replace the actions block in a message with a plain confirmation notice.
+ * Returns the updated blocks array (with the actions block removed).
+ */
+function disableButtons(originalBlocks: Block[], notice: string): Block[] {
+  const withoutActions = originalBlocks.filter((b) => b.type !== "actions");
+  withoutActions.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: notice }],
+  });
+  return withoutActions;
+}
+
+// ── Register all action handlers ───────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function registerActionHandlers(app: App): void {
+
+  // ── 👍 Confirm ────────────────────────────────────────────────────────────
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.action("hypothesis_confirm", async ({ ack, body, client }: any) => {
+    await ack();
+
+    const channel: string = body.container?.channel_id ?? body.channel?.id ?? "";
+    const messageTs: string = body.container?.message_ts ?? body.message?.ts ?? "";
+    const threadTs: string = body.message?.thread_ts ?? messageTs;
+    const userId: string = body.user?.id ?? "unknown";
+
+    // Acknowledge in thread
+    await client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: `✅ Thanks <@${userId}>! Storing this as a confirmed resolution...`,
+    });
+
+    // Persist to knowledge base
+    const result = investigationStore.get(`${channel}-${messageTs}`);
+    if (result) {
+      const { addMockIncident } = await import("@shared/mock-data");
+      const top = result.final_hypotheses[0];
+      const origH = top ? result.investigation.hypotheses[top.original_rank - 1] : undefined;
+      addMockIncident({
+        id: `inc-confirmed-${Date.now()}`,
+        title: result.alert.title,
+        severity: severityToP(result.alert.severity),
+        services: [result.alert.service],
+        occurredAt: result.alert.timestamp.toISOString(),
+        resolvedAt: new Date().toISOString(),
+        durationMinutes: Math.round(result.total_duration_ms / 60_000),
+        rootCause: origH?.description ?? result.investigation.rootCause ?? "Unknown",
+        resolution: origH?.suggestedActions[0] ?? result.investigation.resolution ?? "Unknown",
+        preventionNotes: `Confirmed via Slack by <@${userId}>`,
+      });
+    }
+
+    // Disable buttons on original message
+    const originalBlocks = (body.message?.blocks ?? []) as Block[];
+    await client.chat.update({
+      channel,
+      ts: messageTs,
+      text: formatPlainText(result!),
+      blocks: disableButtons(originalBlocks, `✅ *Confirmed* by <@${userId}>`),
+    });
+  });
+
+  // ── ❌ Reject ─────────────────────────────────────────────────────────────
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.action("hypothesis_reject", async ({ ack, body, client }: any) => {
+    await ack();
+
+    const channel: string = body.container?.channel_id ?? body.channel?.id ?? "";
+    const messageTs: string = body.container?.message_ts ?? body.message?.ts ?? "";
+    const threadTs: string = body.message?.thread_ts ?? messageTs;
+
+    const result = investigationStore.get(`${channel}-${messageTs}`);
+
+    // Register pending rejection so the next thread message triggers re-investigation
+    pendingRejections.set(`${channel}-${threadTs}`, {
+      service: result?.alert.service ?? "",
+      alertId: result?.alert.id ?? "",
+    });
+
+    await client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: `❌ Got it — what was the actual root cause? _(Reply in this thread and I'll re-investigate with your correction.)_`,
+    });
+
+    // Disable buttons on original message
+    const originalBlocks = (body.message?.blocks ?? []) as Block[];
+    const userId: string = body.user?.id ?? "unknown";
+    await client.chat.update({
+      channel,
+      ts: messageTs,
+      text: result ? formatPlainText(result) : "",
+      blocks: disableButtons(originalBlocks, `❌ *Rejected* by <@${userId}> — awaiting correction`),
+    });
+  });
+
+  // ── 🔍 Dig deeper ─────────────────────────────────────────────────────────
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.action("investigate_more", async ({ ack, body, client }: any) => {
+    await ack();
+
+    const channel: string = body.container?.channel_id ?? body.channel?.id ?? "";
+    const messageTs: string = body.container?.message_ts ?? body.message?.ts ?? "";
+    const threadTs: string = body.message?.thread_ts ?? messageTs;
+
+    const result = investigationStore.get(`${channel}-${messageTs}`);
+    if (!result) {
+      await client.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text: "❌ Could not find original investigation context. Please re-investigate manually.",
+      });
+      return;
+    }
+
+    // Disable buttons immediately
+    const originalBlocks = (body.message?.blocks ?? []) as Block[];
+    const userId: string = body.user?.id ?? "unknown";
+    await client.chat.update({
+      channel,
+      ts: messageTs,
+      text: formatPlainText(result),
+      blocks: disableButtons(originalBlocks, `🔍 *Deeper investigation* requested by <@${userId}>`),
+    });
+
+    // Post status message
+    const statusMsg = await client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: "🔍 Running deeper investigation...",
+    });
+    const statusTs: string = statusMsg.ts!;
+
+    // Build context hint from previous findings
+    const top = result.final_hypotheses[0];
+    const origH = top ? result.investigation.hypotheses[top.original_rank - 1] : undefined;
+    const contextHint = [
+      `Previous investigation found:`,
+      origH ? `• Root cause (${top!.revised_confidence}% confidence): ${origH.description}` : "",
+      result.investigation.summary ? `• Summary: ${result.investigation.summary}` : "",
+      ``,
+      `Engineer <@${userId}> requested deeper analysis. Please gather more evidence and refine the hypothesis.`,
+    ].filter(Boolean).join("\n");
+
+    const completedTools: string[] = [];
+
+    try {
+      const { investigate } = await import("@oncall/investigation-agent");
+      const { validate, rerankHypotheses } = await import("@oncall/hypothesis-validator");
+
+      const detectScenario = (service: string): import("@shared/mock-data").ScenarioName => {
+        const lower = service.toLowerCase();
+        if (lower.includes("payment")) return "deploy-regression";
+        if (lower.includes("order")) return "upstream-failure";
+        return "deploy-regression";
+      };
+
+      const invStart = Date.now();
+      const investigation = await investigate(result.alert, {
+        scenario: detectScenario(result.alert.service),
+        maxIterations: 15,
+        contextHint,
+        onToolCall: async (toolNames) => {
+          const { formatToolName } = await import("./incident");
+          completedTools.push(...toolNames.map(formatToolName));
+          const lines = completedTools.map((t) => `✓ ${t}`).join("\n");
+          try {
+            await client.chat.update({
+              channel, ts: statusTs,
+              text: `🔍 Deeper investigation of *${result.alert.service}*...\n${lines}`,
+            });
+          } catch { /* deleted message */ }
+        },
+      });
+      const invDuration = Date.now() - invStart;
+
+      if (investigation.status === "failed") {
+        await client.chat.update({ channel, ts: statusTs,
+          text: `❌ Deeper investigation failed: ${investigation.summary ?? "unknown error"}` });
+        return;
+      }
+
+      await client.chat.update({ channel, ts: statusTs,
+        text: `🧪 Validating hypotheses...\n${completedTools.map((t) => `✓ ${t}`).join("\n")}` });
+
+      const valStart = Date.now();
+      const validation = await validate(investigation, {});
+      const valDuration = Date.now() - valStart;
+
+      const finalHypotheses = rerankHypotheses(validation.validated_hypotheses);
+      const newResult: FullInvestigationResult = {
+        alert: result.alert,
+        investigation,
+        validation,
+        final_hypotheses: finalHypotheses,
+        escalate: validation.escalate,
+        investigation_duration_ms: invDuration,
+        validation_duration_ms: valDuration,
+        total_duration_ms: invDuration + valDuration,
+      };
+
+      if (validation.escalate) {
+        await client.chat.update({ channel, ts: statusTs,
+          text: `🚨 *Escalation required* — ${validation.escalation_reason ?? "low confidence"}` });
+      } else {
+        await client.chat.update({ channel, ts: statusTs, text: `✅ *Deeper investigation complete*` });
+      }
+
+      const newMsg = await client.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text: formatPlainText(newResult),
+        blocks: formatInvestigationResult(newResult),
+      });
+
+      if (newMsg.ts) {
+        investigationStore.set(`${channel}-${newMsg.ts}`, newResult);
+      }
+    } catch (err) {
+      await client.chat.update({ channel, ts: statusTs,
+        text: `❌ Deeper investigation failed: ${(err as Error).message}` });
+    }
+  });
+}
+
+// ── Handle pending rejection replies ──────────────────────────────────────
+
+export async function handlePendingRejection(
+  app: App,
+  channel: string,
+  threadTs: string,
+  correctionText: string,
+  userId: string
+): Promise<void> {
+  const pending = pendingRejections.get(`${channel}-${threadTs}`);
+  if (!pending) return;
+
+  pendingRejections.delete(`${channel}-${threadTs}`);
+
+  // Store the correction in the knowledge base
+  const { addMockIncident } = await import("@shared/mock-data");
+  addMockIncident({
+    id: `inc-correction-${Date.now()}`,
+    title: `Human correction for ${pending.service}`,
+    severity: "P2",
+    services: [pending.service],
+    occurredAt: new Date().toISOString(),
+    resolvedAt: new Date().toISOString(),
+    durationMinutes: 0,
+    rootCause: correctionText,
+    resolution: "Human-provided correction",
+    preventionNotes: `Corrected by <@${userId}>`,
+  });
+
+  await app.client.chat.postMessage({
+    channel,
+    thread_ts: threadTs,
+    text: `Thanks <@${userId}>! Stored your correction. Re-investigating with this context...`,
+  });
+
+  // Re-investigate with the correction as context
+  const statusMsg = await app.client.chat.postMessage({
+    channel,
+    thread_ts: threadTs,
+    text: "🔍 Re-investigating...",
+  });
+  const statusTs = statusMsg.ts!;
+
+  const completedTools: string[] = [];
+
+  try {
+    const { investigate } = await import("@oncall/investigation-agent");
+    const { validate, rerankHypotheses } = await import("@oncall/hypothesis-validator");
+    const { parseAlert } = await import("../alert-parser");
+
+    const alert = await parseAlert(pending.service);
+    alert.labels.channel = channel;
+
+    const contextHint = `Human engineer correction: "${correctionText}"\n\nPlease investigate with this correction in mind.`;
+
+    const invStart = Date.now();
+    const investigation = await investigate(alert, {
+      scenario: "deploy-regression",
+      contextHint,
+      onToolCall: async (toolNames) => {
+        const { formatToolName } = await import("./incident");
+        completedTools.push(...toolNames.map(formatToolName));
+        const lines = completedTools.map((t) => `✓ ${t}`).join("\n");
+        try {
+          await app.client.chat.update({ channel, ts: statusTs,
+            text: `🔍 Re-investigating *${pending.service}*...\n${lines}` });
+        } catch { /* deleted */ }
+      },
+    });
+    const invDuration = Date.now() - invStart;
+
+    if (investigation.status === "failed") {
+      await app.client.chat.update({ channel, ts: statusTs,
+        text: `❌ Re-investigation failed: ${investigation.summary ?? "unknown"}` });
+      return;
+    }
+
+    await app.client.chat.update({ channel, ts: statusTs,
+      text: `🧪 Validating...\n${completedTools.map((t) => `✓ ${t}`).join("\n")}` });
+
+    const valStart = Date.now();
+    const validation = await validate(investigation, {});
+    const valDuration = Date.now() - valStart;
+
+    const finalHypotheses = rerankHypotheses(validation.validated_hypotheses);
+    const newResult: FullInvestigationResult = {
+      alert,
+      investigation,
+      validation,
+      final_hypotheses: finalHypotheses,
+      escalate: validation.escalate,
+      investigation_duration_ms: invDuration,
+      validation_duration_ms: valDuration,
+      total_duration_ms: invDuration + valDuration,
+    };
+
+    if (validation.escalate) {
+      await app.client.chat.update({ channel, ts: statusTs,
+        text: `🚨 *Escalation required* — ${validation.escalation_reason ?? "low confidence"}` });
+    } else {
+      await app.client.chat.update({ channel, ts: statusTs, text: `✅ *Re-investigation complete*` });
+    }
+
+    const newMsg = await app.client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: formatPlainText(newResult),
+      blocks: formatInvestigationResult(newResult),
+    });
+
+    if (newMsg.ts) {
+      investigationStore.set(`${channel}-${newMsg.ts}`, newResult);
+    }
+  } catch (err) {
+    await app.client.chat.update({ channel, ts: statusTs,
+      text: `❌ Re-investigation failed: ${(err as Error).message}` });
+  }
+}
+
+// ── Severity mapper ────────────────────────────────────────────────────────
+
+function severityToP(severity: string): "P1" | "P2" | "P3" | "P4" {
+  switch (severity.toLowerCase()) {
+    case "critical": return "P1";
+    case "high":     return "P2";
+    case "medium":   return "P3";
+    case "low":      return "P4";
+    default:         return "P2";
+  }
+}

--- a/packages/slack-bot/src/handlers/incident.ts
+++ b/packages/slack-bot/src/handlers/incident.ts
@@ -3,6 +3,7 @@ import type { ScenarioName } from "@shared/mock-data";
 import { parseAlert } from "../alert-parser";
 import { formatInvestigationResult, formatPlainText } from "../formatters/investigation";
 import type { FullInvestigationResult } from "@oncall/hypothesis-validator";
+import { investigationStore } from "./actions";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyAnthropicClient = any;
 
@@ -151,12 +152,17 @@ export async function handleIncident(opts: HandleIncidentOptions): Promise<void>
     await safeUpdate(app, channelId, statusTs, `✅ *Investigation complete*`);
   }
 
-  await app.client.chat.postMessage({
+  const resultMsg = await app.client.chat.postMessage({
     channel: channelId,
     thread_ts: threadTs,
     text: formatPlainText(fullResult),
     blocks: formatInvestigationResult(fullResult),
   });
+
+  // Save context so action button handlers can access the investigation result
+  if (resultMsg.ts) {
+    investigationStore.set(`${channelId}-${resultMsg.ts}`, fullResult);
+  }
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/shared/mock-data/incidents.ts
+++ b/shared/mock-data/incidents.ts
@@ -133,3 +133,7 @@ export const mockIncidents: MockIncident[] = [
     preventionNotes: "Cache TTL must be appropriate to data freshness requirements; write-through or invalidate-on-write pattern required for inventory",
   },
 ];
+
+export function addMockIncident(incident: MockIncident): void {
+  mockIncidents.push(incident);
+}

--- a/shared/mock-data/index.ts
+++ b/shared/mock-data/index.ts
@@ -3,7 +3,7 @@ export type { MockIncident } from "./incidents";
 export type * from "./types";
 
 export { mockRunbooks } from "./runbooks";
-export { mockIncidents } from "./incidents";
+export { mockIncidents, addMockIncident } from "./incidents";
 export {
   scenarioAMetrics,
   scenarioBMetrics,


### PR DESCRIPTION
## Summary

- **👍 Confirm** (`hypothesis_confirm`): Posts ack in thread, stores the confirmed root cause + resolution as a new `MockIncident` (visible to future `get_past_incidents` tool calls), replaces buttons with a "✅ Confirmed by @user" context block
- **❌ Reject** (`hypothesis_reject`): Posts root-cause prompt in thread, disables buttons with "Rejected" notice, registers a pending rejection in memory keyed by `channel-thread`; the `app.message` listener catches the next user reply, stores the correction in the knowledge base, and kicks off a re-investigation with the correction as context hint
- **🔍 Dig deeper** (`investigate_more`): Disables buttons immediately, re-runs the full pipeline with `maxIterations: 15` and a context hint summarising previous findings, posts a new Block Kit result in the same thread
- `InvestigateOptions` extended with `maxIterations?` and `contextHint?` so callers can tune the agent loop
- `addMockIncident()` added to `shared/mock-data` so confirmed/corrected resolutions are visible to future investigations
- `investigationStore` in `handlers/actions.ts` is populated by `handleIncident` after posting each result, giving action handlers access to the full context

## Test plan

- [x] 8 new unit tests in `actions.test.ts`: ack fires, confirm posts ✅ message, confirm removes buttons, reject posts root-cause prompt, reject registers pending state, reject removes buttons, dig-deeper posts ❌ when context missing, pending store clears correctly
- [x] All 56 slack-bot tests pass (`bun test packages/slack-bot`)
- [x] TypeScript typecheck clean

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)