### PR TITLE
feat(teams-bot): enhance Adaptive Cards renderer with FactSet, ShowCard, evidence truncation (#27)

### DIFF
--- a/packages/teams-bot/src/__tests__/adaptive-card.test.ts
+++ b/packages/teams-bot/src/__tests__/adaptive-card.test.ts
@@ -74,29 +74,44 @@ function makeBlocks(overrides: Partial<InvestigationBlocks> = {}): Investigation
   };
 }
 
-describe("renderAdaptiveCard", () => {
-  it("returns valid Adaptive Card structure", () => {
+// ── Adaptive Card structure ─────────────────────────────────────────────
+
+describe("renderAdaptiveCard — structure", () => {
+  it("returns valid Adaptive Card v1.5 structure", () => {
     const card = renderAdaptiveCard(makeBlocks());
     expect(card.type).toBe("AdaptiveCard");
-    expect(card.version).toBe("1.4");
+    expect(card.version).toBe("1.5");
     expect(card.$schema).toBe("http://adaptivecards.io/schemas/adaptive-card.json");
     expect(Array.isArray(card.body)).toBe(true);
   });
 
   it("includes header with service name", () => {
     const card = renderAdaptiveCard(makeBlocks());
-    const body = card.body as Array<{ text?: string }>;
-    const header = body.find((b) => b.text?.includes("payment-service"));
+    const body = card.body as Array<{ text?: string; type?: string }>;
+    const header = body.find((b) => b.type === "TextBlock" && b.text?.includes("payment-service"));
     expect(header).toBeDefined();
   });
+});
 
-  it("includes meta line with duration and severity", () => {
+// ── FactSet meta ────────────────────────────────────────────────────────
+
+describe("renderAdaptiveCard — FactSet meta", () => {
+  it("uses FactSet for duration, severity, status, and tool calls", () => {
     const card = renderAdaptiveCard(makeBlocks());
-    const body = card.body as Array<{ text?: string }>;
-    const meta = body.find((b) => b.text?.includes("Duration:") && b.text?.includes("CRITICAL"));
-    expect(meta).toBeDefined();
+    const body = card.body as Array<{ type?: string; facts?: Array<{ title: string; value: string }> }>;
+    const factSet = body.find((b) => b.type === "FactSet");
+    expect(factSet).toBeDefined();
+    const facts = factSet!.facts!;
+    expect(facts.find((f) => f.title === "Duration")?.value).toBe("5.0s");
+    expect(facts.find((f) => f.title === "Severity")?.value).toBe("CRITICAL");
+    expect(facts.find((f) => f.title === "Status")?.value).toBe("completed");
+    expect(facts.find((f) => f.title === "Tool calls")?.value).toBe("4");
   });
+});
 
+// ── Hypotheses ──────────────────────────────────────────────────────────
+
+describe("renderAdaptiveCard — hypotheses", () => {
   it("includes hypothesis with confidence", () => {
     const card = renderAdaptiveCard(makeBlocks());
     const body = card.body as Array<{ text?: string }>;
@@ -104,37 +119,11 @@ describe("renderAdaptiveCard", () => {
     expect(hyp).toBeDefined();
   });
 
-  it("includes action buttons when not escalating", () => {
+  it("includes suggested action and runbook link", () => {
     const card = renderAdaptiveCard(makeBlocks());
-    const actions = card.actions as Array<{ data?: { actionId?: string } }>;
-    expect(actions).toBeDefined();
-    expect(actions.length).toBe(3);
-    const actionIds = actions.map((a) => a.data?.actionId);
-    expect(actionIds).toContain(ACTIONS.CONFIRM);
-    expect(actionIds).toContain(ACTIONS.REJECT);
-    expect(actionIds).toContain(ACTIONS.INVESTIGATE_MORE);
-  });
-
-  it("omits action buttons when escalating", () => {
-    const card = renderAdaptiveCard(makeBlocks({ escalate: true }));
-    expect(card.actions).toBeUndefined();
-  });
-
-  it("shows escalation banner when escalating", () => {
-    const card = renderAdaptiveCard(makeBlocks({
-      escalate: true,
-      validation: {
-        incident_id: "inv-1",
-        validated_hypotheses: [],
-        escalate: true,
-        escalation_reason: "low confidence",
-        validator_notes: "",
-      },
-    }));
-    const body = card.body as Array<{ text?: string; color?: string }>;
-    const banner = body.find((b) => b.text?.includes("Escalation required"));
-    expect(banner).toBeDefined();
-    expect(banner?.color).toBe("Attention");
+    const body = card.body as Array<{ text?: string }>;
+    const runbook = body.find((b) => b.text?.includes("Runbook") && b.text?.includes("wiki.example.com"));
+    expect(runbook).toBeDefined();
   });
 
   it("includes summary text", () => {
@@ -150,11 +139,167 @@ describe("renderAdaptiveCard", () => {
     const notes = body.find((b) => b.text?.includes("Strong evidence"));
     expect(notes).toBeDefined();
   });
+});
 
-  it("includes runbook link", () => {
+// ── Evidence truncation ─────────────────────────────────────────────────
+
+describe("renderAdaptiveCard — evidence truncation", () => {
+  it("truncates evidence at 5 items with overflow note", () => {
+    const blocks = makeBlocks();
+    blocks.originalHypotheses[0]!.evidence = [
+      "e1", "e2", "e3", "e4", "e5", "e6", "e7",
+    ];
+    const card = renderAdaptiveCard(blocks);
+    const body = card.body as Array<{ text?: string }>;
+    const evidenceBlock = body.find((b) => b.text?.includes("Evidence:"));
+    expect(evidenceBlock).toBeDefined();
+    expect(evidenceBlock!.text).toContain("…and 2 more");
+    const bulletCount = (evidenceBlock!.text!.match(/^• /gm) ?? []).length;
+    expect(bulletCount).toBe(5);
+  });
+
+  it("shows all evidence when 5 or fewer", () => {
     const card = renderAdaptiveCard(makeBlocks());
     const body = card.body as Array<{ text?: string }>;
-    const runbook = body.find((b) => b.text?.includes("Runbook") && b.text?.includes("wiki.example.com"));
-    expect(runbook).toBeDefined();
+    const evidenceBlock = body.find((b) => b.text?.includes("Evidence:"));
+    expect(evidenceBlock).toBeDefined();
+    expect(evidenceBlock!.text).not.toContain("…and");
+  });
+});
+
+// ── Action buttons ──────────────────────────────────────────────────────
+
+describe("renderAdaptiveCard — action buttons", () => {
+  it("includes 3 action buttons when not escalating", () => {
+    const card = renderAdaptiveCard(makeBlocks());
+    const actions = card.actions as Array<{ type: string; data?: { actionId?: string } }>;
+    const submitActions = actions.filter((a) => a.type === "Action.Submit");
+    expect(submitActions.length).toBe(3);
+    const actionIds = submitActions.map((a) => a.data?.actionId);
+    expect(actionIds).toContain(ACTIONS.CONFIRM);
+    expect(actionIds).toContain(ACTIONS.REJECT);
+    expect(actionIds).toContain(ACTIONS.INVESTIGATE_MORE);
+  });
+
+  it("omits action buttons when escalating", () => {
+    const card = renderAdaptiveCard(makeBlocks({ escalate: true }));
+    expect(card.actions).toBeUndefined();
+  });
+});
+
+// ── Escalation ──────────────────────────────────────────────────────────
+
+describe("renderAdaptiveCard — escalation", () => {
+  it("shows escalation banner with Attention color and Bolder weight", () => {
+    const card = renderAdaptiveCard(makeBlocks({
+      escalate: true,
+      validation: {
+        incident_id: "inv-1",
+        validated_hypotheses: [],
+        escalate: true,
+        escalation_reason: "low confidence",
+        validator_notes: "",
+      },
+    }));
+    const body = card.body as Array<{ text?: string; color?: string; weight?: string }>;
+    const banner = body.find((b) => b.text?.includes("Escalation required"));
+    expect(banner).toBeDefined();
+    expect(banner?.color).toBe("Attention");
+    expect(banner?.weight).toBe("Bolder");
+  });
+});
+
+// ── Secondary hypotheses (Action.ShowCard) ──────────────────────────────
+
+describe("renderAdaptiveCard — secondary hypotheses", () => {
+  function makeMultiHypBlocks(): InvestigationBlocks {
+    return makeBlocks({
+      hypotheses: [
+        {
+          original_rank: 1,
+          original_confidence: 85,
+          challenge_score: 20,
+          key_objections: ["Could be upstream timeout"],
+          missing_evidence: [],
+          revised_confidence: 80,
+        },
+        {
+          original_rank: 2,
+          original_confidence: 40,
+          challenge_score: 50,
+          key_objections: [],
+          missing_evidence: [],
+          revised_confidence: 30,
+        },
+      ],
+      originalHypotheses: [
+        {
+          id: "h-1",
+          description: "Bad deploy at 14:28 introduced regression",
+          confidence: 85,
+          evidence: ["Error spike correlates with deploy v2.3.1"],
+          relatedServices: ["payment-service"],
+          suggestedActions: ["Rollback to v2.3.0"],
+        },
+        {
+          id: "h-2",
+          description: "Database connection pool exhausted",
+          confidence: 40,
+          evidence: ["High DB latency"],
+          relatedServices: ["payment-service"],
+          suggestedActions: ["Increase pool size"],
+        },
+      ],
+    });
+  }
+
+  it("renders secondary hypotheses in Action.ShowCard", () => {
+    const card = renderAdaptiveCard(makeMultiHypBlocks());
+    const actions = card.actions as Array<{ type: string; title?: string; card?: Record<string, unknown> }>;
+    const showCard = actions.find((a) => a.type === "Action.ShowCard");
+    expect(showCard).toBeDefined();
+    expect(showCard!.title).toContain("1 more hypothesis");
+  });
+
+  it("Action.ShowCard contains hypothesis #2 details", () => {
+    const card = renderAdaptiveCard(makeMultiHypBlocks());
+    const actions = card.actions as Array<{ type: string; card?: { body?: Array<{ text?: string }> } }>;
+    const showCard = actions.find((a) => a.type === "Action.ShowCard");
+    const innerBody = showCard!.card!.body!;
+    const hypBlock = innerBody.find((b) => b.text?.includes("40%") && b.text?.includes("30%"));
+    expect(hypBlock).toBeDefined();
+    const descBlock = innerBody.find((b) => b.text?.includes("Database connection pool"));
+    expect(descBlock).toBeDefined();
+  });
+
+  it("does not render Action.ShowCard for single hypothesis", () => {
+    const card = renderAdaptiveCard(makeBlocks());
+    const actions = card.actions as Array<{ type: string }>;
+    const showCard = actions.find((a) => a.type === "Action.ShowCard");
+    expect(showCard).toBeUndefined();
+  });
+
+  it("pluralizes when 3+ hypotheses", () => {
+    const blocks = makeMultiHypBlocks();
+    blocks.hypotheses.push({
+      original_rank: 3,
+      original_confidence: 20,
+      challenge_score: 70,
+      key_objections: [],
+      missing_evidence: [],
+      revised_confidence: 10,
+    });
+    blocks.originalHypotheses.push({
+      id: "h-3",
+      description: "Network partition",
+      confidence: 20,
+      evidence: [],
+      relatedServices: [],
+      suggestedActions: [],
+    });
+    const card = renderAdaptiveCard(blocks);
+    const actions = card.actions as Array<{ type: string; title?: string }>;
+    const showCard = actions.find((a) => a.type === "Action.ShowCard");
+    expect(showCard!.title).toContain("hypotheses");
   });
 });

--- a/packages/teams-bot/src/formatters/adaptive-card.ts
+++ b/packages/teams-bot/src/formatters/adaptive-card.ts
@@ -1,12 +1,101 @@
 import type { InvestigationBlocks } from "@oncall/bot-core";
+import type { Hypothesis } from "@shared/types";
+import type { ValidatedHypothesis } from "@oncall/bot-core";
 import { ACTIONS, formatDuration } from "@oncall/bot-core";
+
+// ── Evidence formatting ────────────────────────────────────────────────
+
+const MAX_EVIDENCE = 5;
+
+function formatEvidence(evidence: string[]): string {
+  if (!evidence.length) return "_No specific evidence cited._";
+  const shown = evidence.slice(0, MAX_EVIDENCE);
+  const rest = evidence.length - shown.length;
+  const lines = shown.map((e) => `• ${e}`);
+  if (rest > 0) lines.push(`_…and ${rest} more_`);
+  return lines.join("\n");
+}
+
+// ── Confidence emoji ───────────────────────────────────────────────────
+
+function confidenceEmoji(pct: number): string {
+  if (pct >= 80) return "🟢";
+  if (pct >= 50) return "🟡";
+  return "🔴";
+}
+
+// ── Hypothesis card body ───────────────────────────────────────────────
+
+function hypothesisBody(
+  vh: ValidatedHypothesis,
+  origH: Hypothesis | undefined,
+  rank: number,
+  isTop: boolean,
+): Record<string, unknown>[] {
+  const emoji = confidenceEmoji(vh.revised_confidence);
+  const label = isTop ? `**Hypothesis #${rank}** ${emoji}` : `Hypothesis #${rank} ${emoji}`;
+  const items: Record<string, unknown>[] = [];
+
+  items.push({
+    type: "TextBlock",
+    text: `${label} · Confidence: **${vh.original_confidence}%** → **${vh.revised_confidence}%** _(challenge: ${vh.challenge_score}/100)_`,
+    wrap: true,
+    spacing: isTop ? "Medium" : "Small",
+  });
+
+  if (origH) {
+    items.push({
+      type: "TextBlock",
+      text: `> ${origH.description}`,
+      wrap: true,
+      spacing: "None",
+    });
+  }
+
+  if (isTop && origH?.evidence.length) {
+    items.push({
+      type: "TextBlock",
+      text: `**Evidence:**\n${formatEvidence(origH.evidence)}`,
+      wrap: true,
+      spacing: "Small",
+    });
+  }
+
+  if (isTop && vh.key_objections.length) {
+    items.push({
+      type: "TextBlock",
+      text: `🔬 **Adversarial check:** ${vh.key_objections[0]}`,
+      isSubtle: true,
+      spacing: "Small",
+    });
+  }
+
+  if (isTop && origH?.suggestedActions.length) {
+    const action = origH.suggestedActions.find((a) => !a.startsWith("http"));
+    const runbook = origH.suggestedActions.find((a) => a.startsWith("http"));
+    if (action) {
+      let actionText = `**Suggested action:** ${action}`;
+      if (runbook) actionText += ` · [Runbook](${runbook})`;
+      items.push({ type: "TextBlock", text: actionText, wrap: true, spacing: "Small" });
+    }
+  }
+
+  return items;
+}
+
+// ── Main renderer ──────────────────────────────────────────────────────
 
 /**
  * Render InvestigationBlocks as an Adaptive Card JSON payload.
  * This is the Teams-specific counterpart of Slack's renderBlockKit.
+ *
+ * Uses Adaptive Cards v1.5 features:
+ * - FactSet for meta info (duration, severity, tool calls)
+ * - Action.ShowCard for secondary hypotheses (collapsible)
+ * - Evidence truncation with overflow note
  */
 export function renderAdaptiveCard(data: InvestigationBlocks): Record<string, unknown> {
-  const { alert, hypotheses, originalHypotheses, investigation, validation, escalate, duration_ms } = data;
+  const { alert, hypotheses, originalHypotheses, investigation, validation, escalate, duration_ms, tool_call_count } = data;
 
   const body: Record<string, unknown>[] = [];
 
@@ -18,10 +107,15 @@ export function renderAdaptiveCard(data: InvestigationBlocks): Record<string, un
     weight: "Bolder",
   });
 
-  // Meta line
+  // Meta as FactSet
   body.push({
-    type: "TextBlock",
-    text: `**Duration:** ${formatDuration(duration_ms)}  ·  **Severity:** ${alert.severity.toUpperCase()}  ·  **Status:** ${investigation.status}`,
+    type: "FactSet",
+    facts: [
+      { title: "Duration", value: formatDuration(duration_ms) },
+      { title: "Severity", value: alert.severity.toUpperCase() },
+      { title: "Status", value: investigation.status },
+      { title: "Tool calls", value: String(tool_call_count) },
+    ],
     spacing: "Small",
   });
 
@@ -31,7 +125,9 @@ export function renderAdaptiveCard(data: InvestigationBlocks): Record<string, un
       type: "TextBlock",
       text: `⚠️ **Escalation required** — ${validation.escalation_reason ?? "Low-confidence investigation. Human review needed."}`,
       color: "Attention",
+      weight: "Bolder",
       spacing: "Medium",
+      wrap: true,
     });
   }
 
@@ -41,68 +137,21 @@ export function renderAdaptiveCard(data: InvestigationBlocks): Record<string, un
   }
 
   // Separator
-  body.push({ type: "TextBlock", text: "───", spacing: "Small" });
+  body.push({ type: "ColumnSet", separator: true, spacing: "Medium", columns: [] });
 
   // Hypotheses
   if (hypotheses.length === 0) {
     body.push({ type: "TextBlock", text: "_No hypotheses generated._", isSubtle: true });
   } else {
-    hypotheses.forEach((vh, i) => {
-      const origH = originalHypotheses[vh.original_rank - 1];
-      const isTop = i === 0;
-      const emoji = vh.revised_confidence >= 80 ? "🟢" : vh.revised_confidence >= 50 ? "🟡" : "🔴";
-      const label = isTop ? `**Hypothesis #${i + 1}** ${emoji}` : `Hypothesis #${i + 1} ${emoji}`;
-
-      body.push({
-        type: "TextBlock",
-        text: `${label} · Confidence: **${vh.original_confidence}%** → **${vh.revised_confidence}%** _(challenge: ${vh.challenge_score}/100)_`,
-        wrap: true,
-        spacing: i === 0 ? "Medium" : "Small",
-      });
-
-      if (origH) {
-        body.push({
-          type: "TextBlock",
-          text: `> ${origH.description}`,
-          wrap: true,
-          spacing: "None",
-        });
-      }
-
-      if (isTop && origH?.evidence.length) {
-        const evidence = origH.evidence.slice(0, 5).map((e) => `• ${e}`).join("\n");
-        body.push({
-          type: "TextBlock",
-          text: `**Evidence:**\n${evidence}`,
-          wrap: true,
-          spacing: "Small",
-        });
-      }
-
-      if (isTop && vh.key_objections.length) {
-        body.push({
-          type: "TextBlock",
-          text: `🔬 **Adversarial check:** ${vh.key_objections[0]}`,
-          isSubtle: true,
-          spacing: "Small",
-        });
-      }
-
-      if (isTop && origH?.suggestedActions.length) {
-        const action = origH.suggestedActions.find((a) => !a.startsWith("http"));
-        const runbook = origH.suggestedActions.find((a) => a.startsWith("http"));
-        if (action) {
-          let actionText = `**Suggested action:** ${action}`;
-          if (runbook) actionText += ` · [Runbook](${runbook})`;
-          body.push({ type: "TextBlock", text: actionText, wrap: true, spacing: "Small" });
-        }
-      }
-    });
+    // Top hypothesis — always shown inline
+    const topVh = hypotheses[0]!;
+    const topOrigH = originalHypotheses[topVh.original_rank - 1];
+    body.push(...hypothesisBody(topVh, topOrigH, 1, true));
   }
 
   // Validator notes
   if (validation.validator_notes) {
-    body.push({ type: "TextBlock", text: "───", spacing: "Small" });
+    body.push({ type: "ColumnSet", separator: true, spacing: "Small", columns: [] });
     body.push({
       type: "TextBlock",
       text: `🔬 _${validation.validator_notes}_`,
@@ -111,8 +160,11 @@ export function renderAdaptiveCard(data: InvestigationBlocks): Record<string, un
     });
   }
 
-  // Action buttons (only when not escalating)
+  // ── Actions ──────────────────────────────────────────────────────────
+
   const actions: Record<string, unknown>[] = [];
+
+  // Action buttons (only when not escalating)
   if (!escalate && hypotheses.length > 0) {
     actions.push(
       {
@@ -135,10 +187,32 @@ export function renderAdaptiveCard(data: InvestigationBlocks): Record<string, un
     );
   }
 
+  // Secondary hypotheses in collapsible Action.ShowCard
+  if (hypotheses.length > 1) {
+    const secondaryBody: Record<string, unknown>[] = [];
+    for (let i = 1; i < hypotheses.length; i++) {
+      const vh = hypotheses[i]!;
+      const origH = originalHypotheses[vh.original_rank - 1];
+      secondaryBody.push(...hypothesisBody(vh, origH, i + 1, false));
+      if (i < hypotheses.length - 1) {
+        secondaryBody.push({ type: "ColumnSet", separator: true, spacing: "Small", columns: [] });
+      }
+    }
+
+    actions.push({
+      type: "Action.ShowCard",
+      title: `📋 ${hypotheses.length - 1} more ${hypotheses.length - 1 === 1 ? "hypothesis" : "hypotheses"}`,
+      card: {
+        type: "AdaptiveCard",
+        body: secondaryBody,
+      },
+    });
+  }
+
   return {
     type: "AdaptiveCard",
     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-    version: "1.4",
+    version: "1.5",
     body,
     actions: actions.length > 0 ? actions : undefined,
   };


### PR DESCRIPTION
## Summary

- Upgrade to Adaptive Cards v1.5
- Replace meta `TextBlock` with `FactSet` for duration, severity, status, and tool call count
- Add evidence truncation: show max 5 items with "…and N more" overflow note
- Add `Action.ShowCard` for secondary hypotheses — collapsible toggle instead of inline clutter
- Proper `ColumnSet` separators, `Bolder` weight on escalation banner
- Extract reusable `hypothesisBody()` and `formatEvidence()` helpers

## Test plan

- [x] 24 teams-bot tests pass (structure, FactSet, evidence truncation, action buttons, escalation, secondary hypothesis ShowCard with pluralization)
- [x] 18 bot-core tests pass
- [x] 62 slack-bot tests pass
- [x] TypeScript typecheck clean

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)